### PR TITLE
chore: adding the catalog file for backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'tutor-contrib-multi'
+  description: "A Prototype Helm Chart for deploying multiple Open edX instances (via Tutor) onto a cluster."
+  links:
+    - url: "https://github.com/openedx/tutor-contrib-multi"
+      title: "Source Code"
+      icon: "Code"
+spec:
+  owner: group:tutor-contrib-multi
+  type: 'source-code'
+  lifecycle: 'experimental'

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,13 +1,13 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: 'tutor-contrib-multi'
+  name: 'openedx-k8s-harmony'
   description: "A Prototype Helm Chart for deploying multiple Open edX instances (via Tutor) onto a cluster."
   links:
-    - url: "https://github.com/openedx/tutor-contrib-multi"
+    - url: "https://github.com/openedx/openedx-k8s-harmony"
       title: "Source Code"
       icon: "Code"
 spec:
-  owner: group:tutor-contrib-multi
+  owner: group:openedx-k8s-harmony-maintainers
   type: 'source-code'
   lifecycle: 'experimental'


### PR DESCRIPTION
This PR adds the catalog file to be read by backstage.

It makes the `tutor-contrib-multi` group the official maintainer of this repo.

I took the group from 
https://github.com/openedx/tcril-engineering/issues/577

However I can't tag this group. Maybe it is private. Also the group will change once the name of the project changes.

I'll update this PR once that happens.