### PR TITLE
fix: bypassing OCI registries for Harmony chart release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,16 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v3.5
+        with:
+          version: v3.12.3
 
-      - name: Add dependency repositories
+      # The OCI registries are bypassed since helm repo subcommands are not supported.
+      # More details in https://helm.sh/docs/topics/registries/
+      - name: Add dependency repositories (bypassing OCI repositories)
         run: |
           for dir in $(ls -d charts/*/); do
-            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | sed '/oci:\/\//d' | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
           done
 
       - name: Run chart-releaser


### PR DESCRIPTION
This PR aims to fix an issue during the Harmony chart release (check this [failed release](https://github.com/openedx/openedx-k8s-harmony/actions/runs/7096528812/job/19315183193) ). The `helm repo` subcommands are not supported for OCI registries. See https://helm.sh/docs/topics/registries/ to get more details.

It was tested in this [fork](https://github.com/eduNEXT/openedx-k8s-harmony) where the release was generated with success