### PR TITLE
feat: add kubernetes dashboard

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 4.4.2
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.11.0
+  version: v1.13.3
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
   version: 3.8.4
@@ -23,5 +23,8 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 56.6.2
-digest: sha256:8d3ab6c27a75b2ab6106164e38ecfaeaecfb329abc3526c25565f4d6fa6d4ed5
-generated: "2024-02-05T14:59:50.438116+04:00"
+- name: kubernetes-dashboard
+  repository: https://kubernetes.github.io/dashboard
+  version: 7.0.0-alpha1
+digest: sha256:375553f6d86feabc825142f4a142f634712a7748684788bd206b02a5401fa8b3
+generated: "2024-02-23T18:20:26.077091+04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
@@ -22,7 +22,7 @@ dependencies:
   condition: ingress-nginx.enabled
 
 - name: cert-manager
-  version: "1.11.0"
+  version: "1.13.3"
   repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 
@@ -58,3 +58,9 @@ dependencies:
   version: "56.6.2"
   condition: prometheusstack.enabled
   repository: https://prometheus-community.github.io/helm-charts
+
+- name: kubernetes-dashboard
+  version: "7.0.0-alpha1"
+  repository: https://kubernetes.github.io/dashboard
+  alias: k8sdashboard
+  condition: k8sdashboard.enabled

--- a/charts/harmony-chart/templates/NOTES.txt
+++ b/charts/harmony-chart/templates/NOTES.txt
@@ -14,6 +14,17 @@ a JSON response.
 Grafana shipped with the default admin user password as a bug prevents
 changing it. Since is enabled on the cluster and exposed to the internet.
 Please make sure you update the default admin user password!
+{{- if .Values.k8sdashboard.enabled }}
+You have enabled the Kubernetes dashboard. For security purposes, it is not
+exposed to the internet as is, however, by adjusting the settings, you could
+expose it.
+
+To connect to the dashboard, start port-forwarding with the following command:
+
+    kubectl -n harmony port-forward svc/harmony-nginx-controller 8443:443
+
+Now you can connect to https://localhost:8443. The certificate is self-signed by
+the cluster.
 {{- end }}
 
 

--- a/charts/harmony-chart/templates/issuer.yaml
+++ b/charts/harmony-chart/templates/issuer.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: {{ .Release.Name }}-letsencrypt-global
+  name: harmony-letsencrypt-global
 spec:
   acme:
     {{- if index .Values "cert-manager" "email" }}
@@ -10,7 +10,7 @@ spec:
     {{- end }}
     preferredChain: ""
     privateKeySecretRef:
-      name: {{ .Release.Name }}-letsencrypt-global
+      name: harmony-letsencrypt-global
     server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
     - http01:

--- a/charts/harmony-chart/values.yaml
+++ b/charts/harmony-chart/values.yaml
@@ -85,6 +85,23 @@ elasticsearch:
       xpack.security.transport.ssl.certificate_authorities: /usr/share/elasticsearch/config/certs/ca.crt
       xpack.security.transport.ssl.verification_mode: certificate
 
+# Configuration for the metrics server chart
+metricsserver:
+   # Control the chart inclusion
+   enabled: false
+   # See https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
+   # for all available options
+   replicas: 1
+
+# Configuration for the Vertical Pod Autoscaler chart
+vpa:
+   # Control the chart inclusion
+   enabled: false
+   # See https://github.com/cowboysysop/charts/blob/master/charts/vertical-pod-autoscaler/values.yaml
+   # for all available options
+   admissionController:
+      replicaCount: 1
+
 # Multi-tenant OpenSearch
 opensearch:
   enabled: false
@@ -185,6 +202,7 @@ opensearch:
                 ".opendistro-asynchronous-search-response*",
               ]
 
+# Configuration for the Karpenter chart
 karpenter:
   # add Karpenter node management for AWS EKS clusters. See: https://karpenter.sh/
   enabled: false
@@ -311,3 +329,7 @@ prometheusstack:
       requests:
         cpu: 200m
         memory: 256Mi
+
+# Configuration for the K8s Dashboard chart
+k8sdashboard:
+  enabled: false

--- a/values-example.yaml
+++ b/values-example.yaml
@@ -42,3 +42,6 @@ prometheusstack:
 
   # alertmanager:
   #   config: {}  # Set it using `--set-file prometheusstack.alertmanager.config=<path-to-file>`
+
+k8sdashboard:
+  enabled: false

--- a/values-minikube.yaml
+++ b/values-minikube.yaml
@@ -27,3 +27,6 @@ opensearch:
 
 prometheusstack:
   enabled: false
+
+k8sdashboard:
+  enabled: false


### PR DESCRIPTION
This PR resolves https://github.com/openedx/openedx-k8s-harmony/issues/52 by adding K8s dashboard to the charts. The chart is enabled by default to avoid extra resource installations.

I made some smaller adjustments like bumping the cert issues and fixing a wrong doc string.