### PR TITLE
Add optional OpenFAAS chart

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -29,5 +29,8 @@ dependencies:
 - name: velero
   repository: https://vmware-tanzu.github.io/helm-charts
   version: 5.2.0
-digest: sha256:b26b5db88f71eac11257f2f9f4a8f2999738f67456779fb204b9ca593b7f0de3
-generated: "2024-03-25T11:47:55.141915+04:00"
+- name: openfaas
+  repository: https://openfaas.github.io/faas-netes
+  version: 14.2.34
+digest: sha256:17908dd6f2ea4df87042d4bad904965cd4c77e637429acdf1a2a5c1256f85586
+generated: "2024-04-03T18:29:03.753422+04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
@@ -69,3 +69,8 @@ dependencies:
   version: "5.2.0"
   repository: https://vmware-tanzu.github.io/helm-charts
   condition: velero.enabled
+
+- name: openfaas
+  version: "14.2.34"
+  repository: https://openfaas.github.io/faas-netes
+  condition: openfaas.enabled

--- a/charts/harmony-chart/templates/NOTES.txt
+++ b/charts/harmony-chart/templates/NOTES.txt
@@ -28,7 +28,13 @@ Now you can connect to https://localhost:8443. The certificate is self-signed by
 the cluster.
 {{- end }}
 
+{{- if .Values.openfaas.enabled }}
+OpenFAAS is enabled. The default admin user password is automatically generated
+for you by default, and available a secret, called "basic-auth". You can
+retrieve the password by using
 
+    kubectl -n {{ .Release.Namespace }} get secret --template='{{"{{"}}index .data "basic-auth-password"{{"}}"}}' basic-auth
+{{- end }}
 
 {{- /*
 

--- a/charts/harmony-chart/templates/openfaas/namespace.yaml
+++ b/charts/harmony-chart/templates/openfaas/namespace.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.openfaas.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: openfaas-fn
+    name: openfaas-fn
+  name: openfaas-fn
+{{- end }}

--- a/charts/harmony-chart/values.yaml
+++ b/charts/harmony-chart/values.yaml
@@ -370,3 +370,6 @@ velero:
       schedule: "59 23 * * 0"
       template:
         ttl: "720h"
+
+openfaas:
+  enabled: false

--- a/values-example.yaml
+++ b/values-example.yaml
@@ -86,3 +86,6 @@ velero:
       volumeMounts:
         - mountPath: /target
           name: plugins
+
+openfaas:
+  enabled: false

--- a/values-minikube.yaml
+++ b/values-minikube.yaml
@@ -30,3 +30,6 @@ prometheusstack:
 
 k8sdashboard:
   enabled: false
+
+openfaas:
+  enabled: false


### PR DESCRIPTION
This PR resolves #53 by adding an optional OpenFAAS chart to the dependencies.

<img width="1733" alt="Screenshot 2023-12-30 at 12 56 35" src="https://github.com/openedx/openedx-k8s-harmony/assets/19173947/1e68eb40-6ae8-45ae-b1d2-83b5e56af97b">

Example configuration:

```
openfaas:
  enabled: true
  ingress:
    enabled: false
    hosts:
      - host: gateway.openfaas.local  # Replace with gateway.example.com if public-facing
        serviceName: gateway
        servicePort: 8080
        path: /
    annotations:
      kubernetes.io/ingress.class: nginx
      cert-manager.io/cluster-issuer: letsencrypt-prod
      nginx.ingress.kubernetes.io/ssl-redirect: "true" 
      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
```