### PR TITLE
Add optional Velero chart

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -26,5 +26,8 @@ dependencies:
 - name: kubernetes-dashboard
   repository: https://kubernetes.github.io/dashboard
   version: 7.0.0-alpha1
-digest: sha256:375553f6d86feabc825142f4a142f634712a7748684788bd206b02a5401fa8b3
-generated: "2024-02-23T18:20:26.077091+04:00"
+- name: velero
+  repository: https://vmware-tanzu.github.io/helm-charts
+  version: 5.2.0
+digest: sha256:b26b5db88f71eac11257f2f9f4a8f2999738f67456779fb204b9ca593b7f0de3
+generated: "2024-03-25T11:47:55.141915+04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
@@ -64,3 +64,8 @@ dependencies:
   repository: https://kubernetes.github.io/dashboard
   alias: k8sdashboard
   condition: k8sdashboard.enabled
+
+- name: velero
+  version: "5.2.0"
+  repository: https://vmware-tanzu.github.io/helm-charts
+  condition: velero.enabled

--- a/charts/harmony-chart/values.yaml
+++ b/charts/harmony-chart/values.yaml
@@ -85,23 +85,6 @@ elasticsearch:
       xpack.security.transport.ssl.certificate_authorities: /usr/share/elasticsearch/config/certs/ca.crt
       xpack.security.transport.ssl.verification_mode: certificate
 
-# Configuration for the metrics server chart
-metricsserver:
-   # Control the chart inclusion
-   enabled: false
-   # See https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
-   # for all available options
-   replicas: 1
-
-# Configuration for the Vertical Pod Autoscaler chart
-vpa:
-   # Control the chart inclusion
-   enabled: false
-   # See https://github.com/cowboysysop/charts/blob/master/charts/vertical-pod-autoscaler/values.yaml
-   # for all available options
-   admissionController:
-      replicaCount: 1
-
 # Multi-tenant OpenSearch
 opensearch:
   enabled: false
@@ -333,3 +316,57 @@ prometheusstack:
 # Configuration for the K8s Dashboard chart
 k8sdashboard:
   enabled: false
+
+# Before enablin Velero, make sure to execute "velero install --crds-only" to install
+# the CRDs in the cluster.
+velero:
+  enabled: false
+
+  # For the list of supported providers, and their configuration,
+  # please visit https://velero.io/docs/main/supported-providers/
+  configuration:
+    backupStorageLocation:
+      - name: "velero-backup-harmony"
+        provider: aws
+        bucket: ""  # unique name of the bucket
+        default: true
+        config:
+          s3Url: "" # the endpoint can be any S3 compatible storage
+          region: "" # the region of the bucket
+
+    volumeSnapshotLocation:
+      - name: "velero-volume-snapshot-harmony"
+        provider: "" # provider configuration
+        config:
+          region: "" # the region of the bucket
+
+  credentials:
+    secretContents:
+      cloud: |
+        [default]
+        aws_access_key_id=""     # AWS access key ID
+        aws_secret_access_key="" # AWS secret access key
+
+  initContainers:
+    - name: velero-plugin-for-aws
+      image: velero/velero-plugin-for-aws:1.8.4
+      volumeMounts:
+        - mountPath: /target
+          name: plugins
+
+  schedules:
+    hourly-backup:
+      disabled: false
+      schedule: "30 */1 * * *"
+      template:
+        ttl: "24h"
+    daily-backup:
+      disabled: false
+      schedule: "0 6 * * *"
+      template:
+        ttl: "168h"
+    weekly-backup:
+      disabled: false
+      schedule: "59 23 * * 0"
+      template:
+        ttl: "720h"

--- a/values-example.yaml
+++ b/values-example.yaml
@@ -45,3 +45,44 @@ prometheusstack:
 
 k8sdashboard:
   enabled: false
+
+velero:
+  enabled: false
+
+  configuration:
+    backupStorageLocation:
+      - name: velero-backup-harmony
+        provider: aws
+        bucket: se6099-e665a5
+        default: true
+        config:
+          s3Url: https://nyc3.digitaloceanspaces.com
+          region: nyc3
+
+    volumeSnapshotLocation:
+      - name: velero-volume-snapshot-harmony
+        provider: digitalocean.com/velero"
+        config:
+          region: nyc3
+
+  credentials:
+    extraEnvVars:
+        DIGITALOCEAN_TOKEN: ""   # DigitalOcean API token
+    secretContents:
+      cloud: |
+        [default]
+        aws_access_key_id=""     # AWS access key ID
+        aws_secret_access_key="" # AWS secret access key
+
+  initContainers:
+    - name: velero-plugin-for-aws
+      image: velero/velero-plugin-for-aws:1.8.4
+      volumeMounts:
+        - mountPath: /target
+          name: plugins
+
+    - name: velero-plugin-for-digitalocean
+      image: digitalocean/velero-plugin:1.1.0
+      volumeMounts:
+        - mountPath: /target
+          name: plugins


### PR DESCRIPTION
This PR adds optional Velero backups to backup the cluster resources. The backup location can be any S3-compatible storage.

Velero requires CRD installation before enabled, just as the Cert manager. Since we have no dedicated documentation page for the optional resources, I made a note about it in the value examples.

## Screenshot

<img width="1212" alt="Screenshot 2024-01-04 at 11 31 38" src="https://github.com/openedx/openedx-k8s-harmony/assets/19173947/af543113-2762-49a4-9d9a-735025fb62dc">
