### PR TITLE
fix: add missing end-if in notes.txt

### DIFF
--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.

--- a/charts/harmony-chart/templates/NOTES.txt
+++ b/charts/harmony-chart/templates/NOTES.txt
@@ -14,6 +14,7 @@ a JSON response.
 Grafana shipped with the default admin user password as a bug prevents
 changing it. Since is enabled on the cluster and exposed to the internet.
 Please make sure you update the default admin user password!
+{{ end }}
 {{- if .Values.k8sdashboard.enabled }}
 You have enabled the Kubernetes dashboard. For security purposes, it is not
 exposed to the internet as is, however, by adjusting the settings, you could
@@ -26,7 +27,6 @@ To connect to the dashboard, start port-forwarding with the following command:
 Now you can connect to https://localhost:8443. The certificate is self-signed by
 the cluster.
 {{- end }}
-{{ end }}
 
 
 

--- a/charts/harmony-chart/templates/NOTES.txt
+++ b/charts/harmony-chart/templates/NOTES.txt
@@ -26,7 +26,7 @@ To connect to the dashboard, start port-forwarding with the following command:
 Now you can connect to https://localhost:8443. The certificate is self-signed by
 the cluster.
 {{- end }}
-
+{{ end }}
 
 
 


### PR DESCRIPTION
The NOTES.txt currently missing a closing `end` for an `if` statement in the Go template, making it broken and preventing the helm chart to be installed. This PR adds the missing `{{ end }}` to close the initial `{{ if and .Values.prometheusstack.grafana.enabled ... }}` statement.

<img width="645" alt="Screenshot 2024-03-06 at 17 57 31" src="https://github.com/openedx/openedx-k8s-harmony/assets/19173947/c5d49bc8-33ae-421b-9174-f2057729d3f4">

To check the issue, run the following: https://go.dev/play/p/dakeHH1Mrq5
Then to check the fix: https://go.dev/play/p/APXiGU29pci

The difference between the two is the above-mentioned closing tag.