### PR TITLE
chore: update K8s dashboard chart version

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -25,6 +25,6 @@ dependencies:
   version: 56.6.2
 - name: kubernetes-dashboard
   repository: https://kubernetes.github.io/dashboard
-  version: 7.0.0-alpha1
-digest: sha256:375553f6d86feabc825142f4a142f634712a7748684788bd206b02a5401fa8b3
-generated: "2024-02-23T18:20:26.077091+04:00"
+  version: 7.1.2
+digest: sha256:8f20de3cac97574dd7524b5790b08365504b47ec53d91a1a273d5086bd04d517
+generated: "2024-03-27T15:56:14.355662+04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
@@ -60,7 +60,7 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
 
 - name: kubernetes-dashboard
-  version: "7.0.0-alpha1"
+  version: "7.1.2"
   repository: https://kubernetes.github.io/dashboard
   alias: k8sdashboard
   condition: k8sdashboard.enabled


### PR DESCRIPTION
This PR bumps the K8s chart version to the latest available, which provides TLS configuration options. Hence, we are able to set SSL certificates for service, and expose it.