### PR TITLE
chore: bump harmony chart version

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -33,4 +33,4 @@ dependencies:
   repository: https://openfaas.github.io/faas-netes
   version: 14.2.34
 digest: sha256:b636bd16d732d51544ca7223f460e22f45a7132e31e874a789c5fc0cac460a45
-generated: "2024-04-15T14:39:31.262396+04:00"
+generated: "2024-04-22T10:17:39.958678+04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
 #
 # In our case, this represents the version of Tutor that this chart is compatible with.
-appVersion: "16.0.2"
+appVersion: "17.0.4"
 
 dependencies:
 # This is just info for the "helm dependency update" command, which will update the ./charts/ directory when run, using


### PR DESCRIPTION
This PR bumps the harmony chart version to indicate that the chart supports Tutor 17.x (v17.0.4).