### PR TITLE
fix: ensure ES cluster cert name is valid

### DIFF
--- a/charts/harmony-chart/templates/elasticsearch/secrets.yaml
+++ b/charts/harmony-chart/templates/elasticsearch/secrets.yaml
@@ -1,6 +1,6 @@
 ---
 {{- $ca := genCA "elasticca" 1825 }}
-{{- $cn := printf "elasticsearch-master.%s.local" .Release.Namespace }}
+{{- $cn := printf "harmony-search-cluster.%s.svc.cluster.local" .Release.Namespace }}
 {{- $cert := genSignedCert $cn nil (list $cn) 1825 $ca }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
The generated ES self-signed certificate is using an old name of the ES cluster, therefore it cannot be validated. This PR updates the ES cluster name defined in the certificate, so it can be validated, even it is self-signed.