### PR TITLE
chore: bump harmony chart version

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -33,4 +33,4 @@ dependencies:
   repository: https://openfaas.github.io/faas-netes
   version: 14.2.34
 digest: sha256:b636bd16d732d51544ca7223f460e22f45a7132e31e874a789c5fc0cac460a45
-generated: "2024-04-22T10:17:39.958678+04:00"
+generated: "2024-04-26T06:09:47.906542+04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.

--- a/charts/harmony-chart/templates/elasticsearch/secrets.yaml
+++ b/charts/harmony-chart/templates/elasticsearch/secrets.yaml
@@ -1,6 +1,6 @@
 ---
 {{- $ca := genCA "elasticca" 1825 }}
-{{- $cn := printf "elasticsearch-master.%s.local" .Release.Namespace }}
+{{- $cn := printf "harmony-search-cluster.%s.svc.cluster.local" .Release.Namespace }}
 {{- $cert := genSignedCert $cn nil (list $cn) 1825 $ca }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
## Description

As part of https://github.com/openedx/openedx-k8s-harmony/pull/71, the chart version was not updated, hence it cannot be released. This PR bumps the chart version, so it can be released.

## Supporting information

The repo has a release automation which runs on every merge.

### Dependencies

NA