### PR TITLE
refactor: extend ingress hosts

### DIFF
--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
@@ -1,14 +1,17 @@
----
 # For multi-instance clusters. Allow one central load balancer on the cluster to
 # handle HTTPS certs and forward traffic to each Open edX instance's Caddy
 # instance.
-{%- set HOSTS = [LMS_HOST, CMS_HOST, PREVIEW_HOST, MFE_HOST] + K8S_HARMONY_ADDITIONAL_INGRESS_HOST_LIST %}
-{%- HOSTS.append(ECOMMERCE_HOST) if ECOMMERCE_HOST is defined %}
-{%- HOSTS.append(DISCOVERY_HOST) if DISCOVERY_HOST is defined %}
+{%- set HOSTS = [LMS_HOST, CMS_HOST] + K8S_HARMONY_ADDITIONAL_INGRESS_HOST_LIST %}
+{%- set tmp = HOSTS.append(PREVIEW_HOST) if PREVIEW_HOST is defined %}
+{%- set tmp = HOSTS.append(MFE_HOST) if MFE_HOST is defined %}
+{%- set tmp = HOSTS.append(ECOMMERCE_HOST) if ECOMMERCE_HOST is defined %}
+{%- set tmp = HOSTS.append(DISCOVERY_HOST) if DISCOVERY_HOST is defined %}
+{%- for host in HOSTS %}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: central-lb-to-caddy-ingress
+  name: {{ host | replace(".", "-") }}-to-caddy
   namespace: {{ K8S_NAMESPACE }}
   labels:
     app.kubernetes.io/component: ingress
@@ -18,7 +21,6 @@ metadata:
 spec:
   ingressClassName: {{ K8S_HARMONY_INGRESS_CLASS_NAME }}
   rules:
-  {%- for host in HOSTS if host is defined %}
   - host: "{{ host }}"
     http:
       paths:
@@ -29,10 +31,9 @@ spec:
             name: caddy
             port:
               number: {{ CADDY_HTTP_PORT }}
-    {%- endfor %}
   tls:
   - hosts:
-    {%- for host in HOSTS if host is defined %}
-    - {{ host -}}
-    {% endfor %}
+    - {{ host }}
     secretName: central-lb-ingress-tls
+{%- endfor %}
+

--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
@@ -34,6 +34,6 @@ spec:
   tls:
   - hosts:
     - {{ host }}
-    secretName: central-lb-ingress-tls
+    secretName: {{ host | replace(".", "-") }}-tls
 {%- endfor %}
 

--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
@@ -2,7 +2,7 @@
 # For multi-instance clusters. Allow one central load balancer on the cluster to
 # handle HTTPS certs and forward traffic to each Open edX instance's Caddy
 # instance.
-{%- set HOSTS = [LMS_HOST, CMS_HOST, PREVIEW_HOST, MFE_HOST] + K8S_HARMONY_INGRESS_HOST_LIST %}
+{%- set HOSTS = [LMS_HOST, CMS_HOST, PREVIEW_HOST, MFE_HOST] + K8S_HARMONY_ADDITIONAL_INGRESS_HOST_LIST %}
 {%- HOSTS.append(ECOMMERCE_HOST) if ECOMMERCE_HOST is defined %}
 {%- HOSTS.append(DISCOVERY_HOST) if DISCOVERY_HOST is defined %}
 apiVersion: networking.k8s.io/v1

--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
@@ -3,13 +3,17 @@
 # handle HTTPS certs and forward traffic to each Open edX instance's Caddy
 # instance.
 {%- set HOSTS = [LMS_HOST, CMS_HOST, PREVIEW_HOST, MFE_HOST] + K8S_HARMONY_INGRESS_HOST_LIST %}
+{%- HOSTS.append(ECOMMERCE_HOST) if ECOMMERCE_HOST is defined %}
+{%- HOSTS.append(DISCOVERY_HOST) if DISCOVERY_HOST is defined %}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: central-lb-to-caddy-ingress
+  namespace: {{ K8S_NAMESPACE }}
   labels:
     app.kubernetes.io/component: ingress
   annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
     cert-manager.io/cluster-issuer: harmony-letsencrypt-global
 spec:
   ingressClassName: {{ K8S_HARMONY_INGRESS_CLASS_NAME }}

--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
@@ -6,6 +6,8 @@
 {%- set tmp = HOSTS.append(MFE_HOST) if MFE_HOST is defined %}
 {%- set tmp = HOSTS.append(ECOMMERCE_HOST) if ECOMMERCE_HOST is defined %}
 {%- set tmp = HOSTS.append(DISCOVERY_HOST) if DISCOVERY_HOST is defined %}
+{%- set tmp = HOSTS.append(MINIO_HOST) if MINIO_HOST is defined %}
+{%- set tmp = HOSTS.append(MINIO_CONSOLE_HOST) if MINIO_CONSOLE_HOST is defined %}
 {%- for host in HOSTS %}
 ---
 apiVersion: networking.k8s.io/v1

--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/plugin.py
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/plugin.py
@@ -21,7 +21,7 @@ config = {
         # when installing additional plugins such as tutor-ecommerce or tutor-minio.
         # The workaround is to manually add a list of hosts to be routed to the caddy
         # instance.
-        "INGRESS_HOST_LIST": [],
+        "ADDITIONAL_INGRESS_HOST_LIST": [],
         "ENABLE_SHARED_HARMONY_SEARCH": False,
     },
     "overrides": {


### PR DESCRIPTION
## Description

This PR adds the Discovery and Ecommerce hosts to the ingress configuration if the corresponding variables are defined.

## Testing

- Deploy instance
- Setup discovery
- Setup ecommerce (optional as both services are configured the same way)
- Check that discovery loads