### PR TITLE
chore: bump tutor plugin dependency version for redwood support

### DIFF
--- a/tutor-contrib-harmony-plugin/setup.py
+++ b/tutor-contrib-harmony-plugin/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor>=17.0.0,<18.0.0"],
+    install_requires=["tutor>=17.0.0,<19.0.0"],
     entry_points={
         "tutor.plugin.v1": [
             "k8s_harmony = tutor_k8s_harmony_plugin.plugin",


### PR DESCRIPTION
(edit by @gabor-boros):

This PR bumping the required tutor versions to support Redwood. It has been tested that harmony supports Redwood.