### PR TITLE
fix: typo PREVIEW_HOST -> PREVIEW_LMS_HOST

### DIFF
--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
@@ -2,7 +2,7 @@
 # handle HTTPS certs and forward traffic to each Open edX instance's Caddy
 # instance.
 {%- set HOSTS = [LMS_HOST, CMS_HOST] + K8S_HARMONY_ADDITIONAL_INGRESS_HOST_LIST %}
-{%- set tmp = HOSTS.append(PREVIEW_HOST) if PREVIEW_HOST is defined %}
+{%- set tmp = HOSTS.append(PREVIEW_LMS_HOST) if PREVIEW_LMS_HOST is defined %}
 {%- set tmp = HOSTS.append(MFE_HOST) if MFE_HOST is defined %}
 {%- set tmp = HOSTS.append(ECOMMERCE_HOST) if ECOMMERCE_HOST is defined %}
 {%- set tmp = HOSTS.append(DISCOVERY_HOST) if DISCOVERY_HOST is defined %}


### PR DESCRIPTION
Tutor [uses](https://github.com/overhangio/tutor/blob/01d078c28413b7015b81f831934a7720bb668091/tutor/templates/config/defaults.yml#L71) `PREVIEW_LMS_HOST`, thus this fix.