### PR TITLE
chore: bump chart to indicate app version update

### DIFF
--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.4
+version: 0.7.5
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
 #
 # In our case, this represents the version of Tutor that this chart is compatible with.
-appVersion: "17.0.4"
+appVersion: "18.0.0"
 
 dependencies:
 # This is just info for the "helm dependency update" command, which will update the ./charts/ directory when run, using


### PR DESCRIPTION
This PR simply bumps chart version and application version to indicate it supports Redwood.