### PR TITLE
chore(bump): upgrade helm chart global dependencies

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.4.2
+  version: 4.11.2
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.16.0
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
-  version: 3.8.4
+  version: 3.12.1
 - name: vertical-pod-autoscaler
   repository: https://cowboysysop.github.io/charts/
-  version: 6.0.3
+  version: 9.9.0
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.17.3
@@ -19,18 +19,18 @@ dependencies:
   version: 2.13.3
 - name: karpenter
   repository: oci://public.ecr.aws/karpenter
-  version: v0.29.2
+  version: 1.0.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 56.6.2
+  version: 65.0.0
 - name: kubernetes-dashboard
   repository: https://kubernetes.github.io/dashboard
-  version: 7.3.1
+  version: 7.6.1
 - name: velero
   repository: https://vmware-tanzu.github.io/helm-charts
   version: 5.2.0
 - name: openfaas
   repository: https://openfaas.github.io/faas-netes
   version: 14.2.34
-digest: sha256:b636bd16d732d51544ca7223f460e22f45a7132e31e874a789c5fc0cac460a45
-generated: "2024-05-02T12:32:49.796635+04:00"
+digest: sha256:d50c470429a43d05357395ed41fda8c85034643e93ccce67f49bd80c0e2877d9
+generated: "2024-10-03T12:49:09.307756453-05:00"

--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 4.11.2
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.16.0
+  version: v1.15.3
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
   version: 3.12.1
@@ -32,5 +32,5 @@ dependencies:
 - name: openfaas
   repository: https://openfaas.github.io/faas-netes
   version: 14.2.34
-digest: sha256:d50c470429a43d05357395ed41fda8c85034643e93ccce67f49bd80c0e2877d9
-generated: "2024-10-03T12:49:09.307756453-05:00"
+digest: sha256:548b955e15c04e3eb4a270b4f6a869675d20becad8e75702cf945b214809a63e
+generated: "2024-10-07T15:49:37.65074391-05:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -17,24 +17,24 @@ dependencies:
 # This is just info for the "helm dependency update" command, which will update the ./charts/ directory when run, using
 # this information.
 - name: ingress-nginx
-  version: "4.4.2"
+  version: "4.11.2"
   repository: https://kubernetes.github.io/ingress-nginx
   condition: ingress-nginx.enabled
 
 - name: cert-manager
-  version: "1.13.3"
+  version: "1.16.0"
   repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 
 - name: metrics-server
   alias: metricsserver
-  version: "~3.8.3"
+  version: "3.12.1"
   repository: https://kubernetes-sigs.github.io/metrics-server/
   condition: metricsserver.enabled
 
 - name: vertical-pod-autoscaler
   alias: vpa
-  version: "~6.0.3"
+  version: "9.9.0"
   repository: https://cowboysysop.github.io/charts/
   condition: vpa.enabled
 
@@ -49,18 +49,18 @@ dependencies:
   repository: https://opensearch-project.github.io/helm-charts
 
 - name: karpenter
-  version: "v0.29.2"
+  version: "1.0.0"
   repository: oci://public.ecr.aws/karpenter
   condition: karpenter.enabled
 
 - name: kube-prometheus-stack
   alias: prometheusstack
-  version: "56.6.2"
+  version: "65.0.0"
   condition: prometheusstack.enabled
   repository: https://prometheus-community.github.io/helm-charts
 
 - name: kubernetes-dashboard
-  version: "7.3.1"
+  version: "7.6.1"
   repository: https://kubernetes.github.io/dashboard
   alias: k8sdashboard
   condition: k8sdashboard.enabled

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   condition: ingress-nginx.enabled
 
 - name: cert-manager
-  version: "1.16.0"
+  version: "1.15.3"
   repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.5
+version: 0.8.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.

--- a/charts/harmony-chart/templates/issuer.yaml
+++ b/charts/harmony-chart/templates/issuer.yaml
@@ -8,7 +8,6 @@ spec:
     {{- if index .Values "cert-manager" "email" }}
     email: {{ index .Values "cert-manager" "email" }}
     {{- end }}
-    preferredChain: ""
     privateKeySecretRef:
       name: harmony-letsencrypt-global
     server: https://acme-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
### Description

This PR upgrades the helm chart dependencies to the latest version.

Cert manager cannot be upgraded to v1.16 because of this bug: https://github.com/cert-manager/cert-manager/issues/1829

The upgrade was already tested on a production k8s cluster by upgrading from the current version to the new one.