### PR TITLE
build: add renovate bot

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,23 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 0 * * MON"
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Self-hosted Renovate
+      uses: renovatebot/github-action@v40.1.12
+      with:
+        token: ${{ secrets.RENOVATE_PATH }}
+        configurationFile: renovate.json
+      env:
+        RENOVATE_REPOSITORIES: ${{ github.repository }}
+        LOG_LEVEL: info
+        RENOVATE_ONBOARDING: false

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+    "branchPrefix": "renovate/",
+    "pinDigests": false,
+    "prHourlyLimit": 20,
+    "labels": ["global", "dependencies"]
+}


### PR DESCRIPTION
### Description

This PR implements the renovate bot to update helm Chart dependencies.

It was run with a temporal Personal Access Token on a fork. See https://github.com/eduNEXT/openedx-k8s-harmony/pulls for details of the PRs. Here is the log of a successful run: https://github.com/eduNEXT/openedx-k8s-harmony/actions/runs/11521490246/job/32075754011

The upgrades will be easily tested once #80 is merged

frontend-app-authoring already uses [renovate](https://github.com/openedx/frontend-app-authoring/blob/master/renovate.json) to upgrade npm packages.