### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -8,7 +8,7 @@ jobs:
 
   push:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/harmony-plugin')
+    # if: startsWith(github.ref, 'refs/tags/harmony-plugin')
     defaults:
       run:
         working-directory: ./tutor-contrib-harmony-plugin

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,14 +1,12 @@
 name: Publish package to PyPi
 
 on:
-  release:
-    types: [published]
+  push
 
 jobs:
 
   push:
     runs-on: ubuntu-latest
-    # if: startsWith(github.ref, 'refs/tags/harmony-plugin')
     defaults:
       run:
         working-directory: ./tutor-contrib-harmony-plugin

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,0 +1,35 @@
+name: Publish package to PyPi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  push:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/harmony-plugin')
+    defaults:
+      run:
+        working-directory: ./tutor-contrib-harmony-plugin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
+      - name: Install Dependencies
+        run: pip install setuptools wheel
+
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+          packages-dir: tutor-contrib-harmony-plugin/dist

--- a/tutor-contrib-harmony-plugin/setup.py
+++ b/tutor-contrib-harmony-plugin/setup.py
@@ -26,7 +26,7 @@ ABOUT = load_about()
 
 
 setup(
-    name="tutor-contrib-harmony-plugin",
+    name="tutor-contrib-harmony",
     version=ABOUT["__version__"],
     url="https://github.com/openedx/openedx-k8s-harmony",
     project_urls={


### PR DESCRIPTION
This PR adds a release workflow to upload the tutor-contrib-harmony plugin to pypi.

This was tested on a fork: https://github.com/eduNEXT/openedx-k8s-harmony/actions/runs/12011623600/job/33481030042, it failed because the PyPi token was missing