### PR TITLE
fix: removing cert-manager invalid value

### DIFF
--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.

--- a/charts/harmony-chart/values.yaml
+++ b/charts/harmony-chart/values.yaml
@@ -12,9 +12,6 @@ cert-manager:
   # Use cert-manager as a default certificate controller.
   enabled: true
   installCRDs: false
-    # Email address associated with the ACME account. Used to notify about expiring
-    # certificates.
-  email: ""
 
 # Configuration for the metrics server chart
 metricsserver:


### PR DESCRIPTION
The cert-manager validations are strict so it won't accept un-supported values in the chart configuration. This PR removes the `email` (it is not supported in the current chart version) value from the cert-manager configuration to prevent failures in installing the Harmony chart.