### PR TITLE
fix: adding resources only if right subcharts are enabled

### DIFF
--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.

--- a/charts/harmony-chart/templates/echo.yaml
+++ b/charts/harmony-chart/templates/echo.yaml
@@ -1,5 +1,6 @@
 # This service, which is always enabled, allows you to do basic health checks of your cluster and the Ingress Controller
 # Service by accessing /cluster-echo-test via HTTP on any hostname associated with your cluster.
+{{- if index .Values "ingress-nginx" "enabled" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -57,3 +58,4 @@ spec:
             name: cluster-echo-service
             port:
               number: 8080
+{{- end }}

--- a/charts/harmony-chart/templates/elasticsearch/secrets.yaml
+++ b/charts/harmony-chart/templates/elasticsearch/secrets.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.elasticsearch.enabled }}
 {{- $ca := genCA "elasticca" 1825 }}
 {{- $cn := printf "harmony-search-cluster.%s.svc.cluster.local" .Release.Namespace }}
 {{- $cert := genSignedCert $cn nil (list $cn) 1825 $ca }}
@@ -20,3 +20,4 @@ metadata:
 type: Opaque
 data:
   "password": {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}

--- a/charts/harmony-chart/templates/opensearch/secrets.yaml
+++ b/charts/harmony-chart/templates/opensearch/secrets.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.opensearch.enabled }}
 {{- $ca := genCA "opensearchca" 1825 }}
 {{- $cn := printf "harmony-search-cluster.%s.svc.cluster.local" .Release.Namespace }}
 {{- $cert := genSignedCert $cn nil (list $cn) 1825 $ca }}
@@ -23,3 +23,4 @@ type: Opaque
 data:
   password: {{ $password | b64enc | quote }}
   internal_users.yml: {{ printf "---\n_meta:\n  type: \"internalusers\"\n  config_version: 2\n\nharmony:\n  hash: \"%s\"\n  reserved: true\n  backend_roles:\n    - \"admin\"\n  description: \"Harmony admin user\"\n" $password_bcrypt | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
In the Harmony Chart templates, there are resources whose existence must be conditioned to the activation/deactivation of a specific subchart. In this PR conditionals are added to create specific resources only when the related subchart is enabled