### PR TITLE
chore: bump harmony chart version

### DIFF
--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.


### PR DESCRIPTION
This PR bumps the Harmony chart version to cut a new release, including the minor changes opened by Renovate bot. The changes are:

- 5586ce1ac39c2551d3837f2de8d3cb13230a98ca
- e6cacb010b204fe980bcf0befb70cf0e1536db68
- 2af8298ae71c0df6ea1ab1b0f7a19772a6dbcf91
- a7503bb340cdaf36f49f76dd88f8e7c9ffcfb22d
- cff7dc9650b687e7a69ba2d2d2626dcedef56e1a
- 9ae5f94c97a9de34b84e845e450b422200a4249e
- 0ec8ee03eb8d616106ad09fd381ec2a58c58e13a
- 121cd8f75fd3c2ca5d1c12f336601c15c6a33aff