### PR TITLE
fix: ensure let's encrypt email can be set

### DIFF
--- a/charts/harmony-chart/templates/issuer.yaml
+++ b/charts/harmony-chart/templates/issuer.yaml
@@ -5,8 +5,8 @@ metadata:
   name: harmony-letsencrypt-global
 spec:
   acme:
-    {{- if index .Values "cert-manager" "email" }}
-    email: {{ index .Values "cert-manager" "email" }}
+    {{- if .Values.notificationEmail }}
+    email: {{ .Values.notificationEmail }}
     {{- end }}
     privateKeySecretRef:
       name: harmony-letsencrypt-global

--- a/charts/harmony-chart/values.yaml
+++ b/charts/harmony-chart/values.yaml
@@ -4,6 +4,10 @@
 
 clusterDomain: "*"
 
+# Email address used for receiving Let's encrypt notifications if cert-manager
+# is enabled.
+notificationEmail: null
+
 ingress-nginx:
   # Use ingress-nginx as a default controller.
   enabled: true


### PR DESCRIPTION
This PR is supposed to fix the removal of `email` field from the `cert-manager` key. More info: https://github.com/openedx/openedx-k8s-harmony/pull/126#issuecomment-2547688485