### PR TITLE
Adds MEILISEARCH_HOST to ingress.

### DIFF
--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/k8s-services
@@ -8,6 +8,7 @@
 {%- set tmp = HOSTS.append(DISCOVERY_HOST) if DISCOVERY_HOST is defined %}
 {%- set tmp = HOSTS.append(MINIO_HOST) if MINIO_HOST is defined %}
 {%- set tmp = HOSTS.append(MINIO_CONSOLE_HOST) if MINIO_CONSOLE_HOST is defined %}
+{%- set tmp = HOSTS.append(MEILISEARCH_HOST) if MEILISEARCH_HOST is defined %}
 {%- for host in HOSTS %}
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
MEILISEARCH_HOST is introduced so that we can add it to the ingress controller


**Discussions**: [Slack Discussion](https://openedx.slack.com/archives/C05519HHZKM/p1739341680191669?thread_ts=1739257428.215229&cid=C05519HHZKM)

**Dependencies**: None

~~**Screenshots**: Always include screenshots if there is any change to the UI.~~

**Testing instructions**:

None

Private ref: [BB-9563](https://tasks.opencraft.com/browse/BB-9563)


REF: https://github.com/overhangio/tutor/pull/1209