### PR TITLE
chore: bump ingress-nginx and format file

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.11.3
+  version: 4.11.5
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.16.2
@@ -35,5 +35,5 @@ dependencies:
 - name: vector
   repository: https://helm.vector.dev
   version: 0.37.0
-digest: sha256:f470a766885ea840bc6b822c07c5ff55bff415195bd3bb76c2f37f89c75a460d
-generated: "2024-12-17T05:51:57.22165494Z"
+digest: sha256:a85bf11b69911769b19202ae261c21f3e3b6e4e2d3714561da13775698be3fd9
+generated: "2025-03-28T18:50:31.908422+04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.4
+version: 0.9.5
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -14,68 +14,68 @@ version: 0.9.4
 appVersion: "18.0.0"
 
 dependencies:
-# This is just info for the "helm dependency update" command, which will update the ./charts/ directory when run, using
-# this information.
-- name: ingress-nginx
-  version: "4.11.3"
-  repository: https://kubernetes.github.io/ingress-nginx
-  condition: ingress-nginx.enabled
+  # This is just info for the "helm dependency update" command, which will update the ./charts/ directory when run, using
+  # this information.
+  - name: ingress-nginx
+    version: "4.11.5"
+    repository: https://kubernetes.github.io/ingress-nginx
+    condition: ingress-nginx.enabled
 
-- name: cert-manager
-  version: "v1.16.2"
-  repository: https://charts.jetstack.io
-  condition: cert-manager.enabled
+  - name: cert-manager
+    version: "v1.16.2"
+    repository: https://charts.jetstack.io
+    condition: cert-manager.enabled
 
-- name: metrics-server
-  alias: metricsserver
-  version: "3.12.2"
-  repository: https://kubernetes-sigs.github.io/metrics-server/
-  condition: metricsserver.enabled
+  - name: metrics-server
+    alias: metricsserver
+    version: "3.12.2"
+    repository: https://kubernetes-sigs.github.io/metrics-server/
+    condition: metricsserver.enabled
 
-- name: vertical-pod-autoscaler
-  alias: vpa
-  version: "9.9.0"
-  repository: https://cowboysysop.github.io/charts/
-  condition: vpa.enabled
+  - name: vertical-pod-autoscaler
+    alias: vpa
+    version: "9.9.0"
+    repository: https://cowboysysop.github.io/charts/
+    condition: vpa.enabled
 
-- name: elasticsearch
-  version: "7.17.3"
-  condition: elasticsearch.enabled
-  repository: https://helm.elastic.co
+  - name: elasticsearch
+    version: "7.17.3"
+    condition: elasticsearch.enabled
+    repository: https://helm.elastic.co
 
-- name: opensearch
-  version: "2.13.3"
-  condition: opensearch.enabled
-  repository: https://opensearch-project.github.io/helm-charts
+  - name: opensearch
+    version: "2.13.3"
+    condition: opensearch.enabled
+    repository: https://opensearch-project.github.io/helm-charts
 
-- name: karpenter
-  version: "1.0.8"
-  repository: oci://public.ecr.aws/karpenter
-  condition: karpenter.enabled
+  - name: karpenter
+    version: "1.0.8"
+    repository: oci://public.ecr.aws/karpenter
+    condition: karpenter.enabled
 
-- name: kube-prometheus-stack
-  alias: prometheusstack
-  version: "65.8.1"
-  condition: prometheusstack.enabled
-  repository: https://prometheus-community.github.io/helm-charts
+  - name: kube-prometheus-stack
+    alias: prometheusstack
+    version: "65.8.1"
+    condition: prometheusstack.enabled
+    repository: https://prometheus-community.github.io/helm-charts
 
-- name: kubernetes-dashboard
-  version: "7.10.0"
-  repository: https://kubernetes.github.io/dashboard
-  alias: k8sdashboard
-  condition: k8sdashboard.enabled
+  - name: kubernetes-dashboard
+    version: "7.10.0"
+    repository: https://kubernetes.github.io/dashboard
+    alias: k8sdashboard
+    condition: k8sdashboard.enabled
 
-- name: velero
-  version: "5.4.1"
-  repository: https://vmware-tanzu.github.io/helm-charts
-  condition: velero.enabled
+  - name: velero
+    version: "5.4.1"
+    repository: https://vmware-tanzu.github.io/helm-charts
+    condition: velero.enabled
 
-- name: openfaas
-  version: "14.2.87"
-  repository: https://openfaas.github.io/faas-netes
-  condition: openfaas.enabled
+  - name: openfaas
+    version: "14.2.87"
+    repository: https://openfaas.github.io/faas-netes
+    condition: openfaas.enabled
 
-- name: vector
-  version:  0.37.0
-  repository: https://helm.vector.dev
-  condition: vector.enabled
+  - name: vector
+    version: 0.37.0
+    repository: https://helm.vector.dev
+    condition: vector.enabled


### PR DESCRIPTION
This PR bumps the ingress-nginx chart version due to a vulnerability in the current chart.