### PR TITLE
Make the s3 bucket name available

### DIFF
--- a/terraform/modules/aws/s3/README.md
+++ b/terraform/modules/aws/s3/README.md
@@ -47,3 +47,4 @@ No modules.
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | The unique resource ID of the bucket. |
 | <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | The domain name of the bucket, including the generated prefix. |
 | <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | The ID of the bucket that is generated during creation. |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | The name of the S3 bucket. |

--- a/terraform/modules/aws/s3/outputs.tf
+++ b/terraform/modules/aws/s3/outputs.tf
@@ -8,7 +8,13 @@ output "bucket_arn" {
   description = "The unique resource ID of the bucket."
 }
 
+output "bucket_name" {
+   value       = aws_s3_bucket.s3_bucket.name 
+   description = "The name of the S3 bucket."
+}
+
 output "bucket_domain_name" {
   value       = aws_s3_bucket.s3_bucket.bucket_domain_name
   description = "The domain name of the bucket, including the generated prefix."
 }
+


### PR DESCRIPTION
The S3 bucket name is not in the output for AWS S3 module. This PR adds the bucket name to the exposed values.