### PR TITLE
feat: migrate cluster dashboard from legacy k8s-dashboard to Headlamp

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -23,14 +23,14 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 81.0.1
-- name: kubernetes-dashboard
-  repository: https://kubernetes-retired.github.io/dashboard
-  version: 7.14.0
+- name: headlamp
+  repository: https://kubernetes-sigs.github.io/headlamp/
+  version: 0.40.0
 - name: velero
   repository: https://vmware-tanzu.github.io/helm-charts
   version: 5.4.1
 - name: vector
   repository: https://helm.vector.dev
   version: 0.50.0
-digest: sha256:0c9ece5b8130e4536ab5357e0b08dfdb1448365138796990a6b3ff7957d64f02
-generated: "2026-02-19T17:01:07.30458+04:00"
+digest: sha256:e7d16499c28ac60175ddebf3d280e33c38ef6671b44c10f2da6646e87b7fba8c
+generated: "2026-02-19T21:50:40.423690684-04:00"

--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -25,12 +25,12 @@ dependencies:
   version: 81.0.1
 - name: headlamp
   repository: https://kubernetes-sigs.github.io/headlamp/
-  version: 0.40.0
+  version: 0.43.0
 - name: velero
   repository: https://vmware-tanzu.github.io/helm-charts
   version: 5.4.1
 - name: vector
   repository: https://helm.vector.dev
   version: 0.50.0
-digest: sha256:e7d16499c28ac60175ddebf3d280e33c38ef6671b44c10f2da6646e87b7fba8c
-generated: "2026-02-19T21:50:40.423690684-04:00"
+digest: sha256:beb4ce4eaf308c34c1a09b249056ac239c0e91d511a7c2f3182bb1c208fac6c2
+generated: "2026-07-06T19:58:47.601688732-04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -59,11 +59,11 @@ dependencies:
     condition: prometheusstack.enabled
     repository: https://prometheus-community.github.io/helm-charts
 
-  - name: kubernetes-dashboard
-    version: "7.14.0"
-    repository: https://kubernetes-retired.github.io/dashboard
-    alias: k8sdashboard
-    condition: k8sdashboard.enabled
+  - name: headlamp
+    version: "0.40.0"
+    repository: https://kubernetes-sigs.github.io/headlamp/
+    alias: headlamp
+    condition: headlamp.enabled
 
   - name: velero
     version: "5.4.1"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.12.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
@@ -60,7 +60,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
 
   - name: headlamp
-    version: "0.40.0"
+    version: "0.43.0"
     repository: https://kubernetes-sigs.github.io/headlamp/
     alias: headlamp
     condition: headlamp.enabled

--- a/charts/harmony-chart/templates/NOTES.txt
+++ b/charts/harmony-chart/templates/NOTES.txt
@@ -15,17 +15,20 @@ Grafana shipped with the default admin user password as a bug prevents
 changing it. Since is enabled on the cluster and exposed to the internet.
 Please make sure you update the default admin user password!
 {{ end }}
-{{- if .Values.k8sdashboard.enabled }}
-You have enabled the Kubernetes dashboard. For security purposes, it is not
-exposed to the internet as is, however, by adjusting the settings, you could
-expose it.
+{{- if .Values.headlamp.enabled }}
+You have enabled the Headlamp dashboard. This is a modern UI for managing your
+Kubernetes cluster. For security purposes, it is recommended to restrict access
+via Ingress annotations or VPN.
 
-To connect to the dashboard, start port-forwarding with the following command:
+To connect to the dashboard:
 
-    kubectl -n harmony port-forward svc/harmony-nginx-controller 8443:443
+1. Visit the dashboard URL configured in your Ingress.
+2. To log in, you will need an authentication token. You can retrieve the
+   admin token with the following command:
 
-Now you can connect to https://localhost:8443. The certificate is self-signed by
-the cluster.
+    kubectl -n {{ .Release.Namespace }} get secret admin-user-token -o jsonpath={.data.token} | base64 -d
+
+Copy the output and paste it into the "Token" field on the login screen.
 {{- end }}
 
 {{- /*

--- a/charts/harmony-chart/values.yaml
+++ b/charts/harmony-chart/values.yaml
@@ -305,8 +305,8 @@ prometheusstack:
         cpu: 200m
         memory: 256Mi
 
-# Configuration for the K8s Dashboard chart
-k8sdashboard:
+# Configuration for headlamp
+headlamp:
   enabled: false
 
 # Before enablin Velero, make sure to execute "velero install --crds-only" to install

--- a/integration-test/elasticsearch/values.yaml
+++ b/integration-test/elasticsearch/values.yaml
@@ -43,5 +43,5 @@ opensearch:
 prometheusstack:
   enabled: true
 
-k8sdashboard:
+headlamp:
   enabled: false

--- a/integration-test/template/values.yaml
+++ b/integration-test/template/values.yaml
@@ -43,5 +43,5 @@ opensearch:
 prometheusstack:
   enabled: false
 
-k8sdashboard:
+headlamp:
   enabled: false

--- a/values-example.yaml
+++ b/values-example.yaml
@@ -43,7 +43,7 @@ prometheusstack:
   # alertmanager:
   #   config: {}  # Set it using `--set-file prometheusstack.alertmanager.config=<path-to-file>`
 
-k8sdashboard:
+headlamp:
   enabled: false
 
 velero:

--- a/values-minikube.yaml
+++ b/values-minikube.yaml
@@ -28,5 +28,5 @@ opensearch:
 prometheusstack:
   enabled: true
 
-k8sdashboard:
+headlamp:
   enabled: false


### PR DESCRIPTION
# Description
This PR replaces the **deprecated** `kubernetes-dashboard` with **Headlamp**, a modern, extensible, and open-source Kubernetes UI from Kubernetes SIGs. 

Since the original dashboard has been moved to a "retired" status, this migration ensures the Harmony project remains up-to-date with current Kubernetes ecosystem standards.

## Key Changes

### 1. Chart Dependency Update
* **Removed**: `kubernetes-dashboard` (v7.14.0) from the `kubernetes-retired` repository.
* **Added**: `headlamp` (v0.43.0) from the `kubernetes-sigs` official repository.

### 2. Values Configuration
* Refactored `values.yaml` to replace the `k8sdashboard` key with `headlamp`.
* Updated comments and internal references to reflect Headlamp as the default cluster UI.
* Cleaned up `templates/NOTES.txt` to prevent `nil pointer` evaluation errors when legacy dashboard values are absent.

## Recommended Configuration
### Ingress Values
The following configuration is recommended for production-like environments using **Nginx Ingress** and **Cert-Manager**. 

> **Note:** Headlamp's internal service operates on port 80 (HTTP). The Ingress is configured for SSL Termination (HTTPS externally, HTTP internally) to avoid 502/503 errors.

```yaml
headlamp:
  enabled: true
  ingress:
    enabled: true
    ingressClassName: nginx
    annotations:
      cert-manager.io/cluster-issuer: "letsencrypt-global"
      nginx.ingress.kubernetes.io/ssl-redirect: "true"
      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
      # Required to match Headlamp's default service protocol
      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
    tls:
      - hosts:
          - url.dashboard.example.net
        secretName: headlamp-tls
    hosts:
      - host: url.dashboard.example.net
        paths:
          - path: /
            type: Prefix
```
###  Security & RBAC
Unlike the previous panel, Headlamp requires explicit authentication. This example provides a GitOps-compatible RBAC configuration that automates token generation for Kubernetes 1.24+ via Secret annotations.

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: admin-user
  namespace: {namespace}
---
apiVersion: v1
kind: Secret
metadata:
  name: admin-user-token
  namespace: {namespace}
  annotations:
    # Triggers automatic token generation
    kubernetes.io/service-account.name: admin-user
type: kubernetes.io/service-account-token
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: admin-user-binding
subjects:
- kind: ServiceAccount
  name: admin-user
  namespace: {namespace}
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
```
## Migration Guide
For existing installations:

1. Cleanup: The old dashboard will be automatically disabled as the k8sdashboard key is no longer supported.

2. Activation: Set headlamp.enabled: true in your implementation values and add the configurations in the ingress value shown in the examples.

3. Authentication: After implementation and if I configure RBAC as shown in the previous steps, retrieve the login token by running:

```Bash
kubectl -n {namespace} get secret admin-user-token -o jsonpath={.data.token} | base64 -d
