### PR TITLE
feat: add support for traefik Ingress controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,170 @@
 # Harmony Project - Open edX on Kubernetes
 
-This project is focused on making it easy to set up a standardized, scalable, secure Kubernetes environment that can host **multiple instances** of [Open edX](https://www.openedx.org). See [Motivation](#motivation) below.
+This project is focused on making it easy to set up a standardized, scalable,
+secure Kubernetes environment that can host **multiple instances** of
+[Open edX](https://www.openedx.org). See [Motivation](#motivation) below.
 
 Specifically, this repository contains:
 
-* A Helm Chart that can install necessary shared resources into your cluster (a load balancer / ingress controller, autoscaling infrastructure, monitoring tools, databases, etc.)
-* A [Tutor](https://docs.tutor.overhang.io/) plugin that configures Tutor to build images that will use the shared resources deployed by the Helm chart.
+* A Helm Chart that can install necessary shared resources into your cluster (a
+  load balancer / ingress controller, autoscaling infrastructure, monitoring
+  tools, databases, etc.)
+* A [Tutor](https://docs.tutor.overhang.io/) plugin that configures Tutor to
+  build images that will use the shared resources deployed by the Helm chart.
 
-This repository does not set up the Kubernetes cluster or provision individual Open edX instances.
+This repository does not set up the Kubernetes cluster or provision individual
+Open edX instances.
 
-See [technology stack and architecture](#technology-stack-and-architecture) below for more details.
+See [technology stack and architecture](#technology-stack-and-architecture)
+below for more details.
 
 ## Motivation
 
-Many Open edX providers and users have a need to deploy multiple instances of Open edX onto Kubernetes, but there is currently no standardized way to do so and each provider must build their own tooling to manage that. This project aims to provide an easy and standardized approach that incorporates industry best practices and lessons learned.
+Many Open edX providers and users have a need to deploy multiple instances of
+Open edX onto Kubernetes, but there is currently no standardized way to do so
+and each provider must build their own tooling to manage that. This project aims
+to provide an easy and standardized approach that incorporates industry best
+practices and lessons learned.
 
-In particular, this project aims to provide the following benefits to Open edX operators:
+In particular, this project aims to provide the following benefits to Open edX
+operators:
 
-* **Ease of use** and **rapid deployment**: This project aims to provide an Open edX hosting environment that just works out of the box, that can be easily upgraded, and that follows best practices for monitoring, security, etc.
-* **Lower costs** by sharing resources where it makes sense. For example, by default Tutor's k8s feature will deploy a separate load balancer and ingress controller for each Open edX instance, instead of a shared ingress controller for all the instances in the cluster. Likewise for MySQL, MongoDB, ElasticSearch, and other resources. By using shared resources by default, costs can be dramatically reduced and operational monitoring and maintenance is greatly simplified.
-  * For setups with many small instances, this shared approach provides a huge cost savings with virtually no decrease in performance.
-  * For larger instances on the cluster that need dedicated resources, they can easily be configured to do so.
-* **Scalable hosting** for instances of any size. This means for example that the default configuration includes autoscaling of LMS pods to handle increased traffic.
-* **Flexibility**: this project aims to be "batteries included" and to support setting up all the resources that you need, with useful default configurations, but it is carefully designed so that operators can configure, replace, or disable any components as needed.
+* **Ease of use** and **rapid deployment**: This project aims to provide an Open
+  edX hosting environment that just works out of the box, that can be easily
+  upgraded, and that follows best practices for monitoring, security, etc.
+* **Lower costs** by sharing resources where it makes sense. For example, by
+  default Tutor's k8s feature will deploy a separate load balancer and ingress
+  controller for each Open edX instance, instead of a shared ingress controller
+  for all the instances in the cluster. Likewise for MySQL, MongoDB,
+  ElasticSearch, and other resources. By using shared resources by default,
+  costs can be dramatically reduced and operational monitoring and maintenance
+  is greatly simplified.
+  * For setups with many small instances, this shared approach provides a huge
+    cost savings with virtually no decrease in performance.
+  * For larger instances on the cluster that need dedicated resources, they can
+    easily be configured to do so.
+* **Scalable hosting** for instances of any size. This means for example that
+  the default configuration includes autoscaling of LMS pods to handle increased
+  traffic.
+* **Flexibility**: this project aims to be "batteries included" and to support
+  setting up all the resources that you need, with useful default
+  configurations, but it is carefully designed so that operators can configure,
+  replace, or disable any components as needed.
 
 ## Technology stack and architecture
 
-1. At the base is a Kubernetes cluster, which you must provide (e.g. using OpenTofu to provision Amazon EKS).
-   * Any cloud provider such as AWS or Digital Ocean should work. There are OpenTofu examples in the `infra-examples` folder but it is just a starting point and not recommended for production use.
-2. On top of that, this project's helm chart will install the shared resources you need - an ingress controller, monitoring, database clusters, etc. The following are included but can be disabled/replaced if you prefer an alternative:
-   * Ingress controller: [ingress-nginx](https://kubernetes.github.io/ingress-nginx/)
+1. At the base is a Kubernetes cluster, which you must provide (e.g. using
+   OpenTofu to provision Amazon EKS).
+   * Any cloud provider such as AWS or Digital Ocean should work. There are
+     OpenTofu examples in the `infra-examples` folder but it is just a starting
+     point and not recommended for production use.
+2. On top of that, this project's helm chart will install the shared resources
+   you need - an ingress controller, monitoring, database clusters, etc. The
+   following are included but can be disabled/replaced if you prefer an
+   alternative:
+   * Ingress controller:
+     [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) and
+     [Traefik](https://traefik.io/traefik/) (Traefik is replacing ingress-nginx
+     in the upcoming release)
    * Automatic HTTPS cert provisioning: [cert-manager](https://cert-manager.io/)
    * Autoscaling: `metrics-server` and `vertical-pod-autoscaler`
    * Search index: ElasticSearch or OpenSearch
-   * Monitoring: TODO
-   * Database clusters: TODO (for now we recommend provisioning managed MySQL/MongoDB database clusters from your cloud provider using OpenTofu or a tool like [Grove](https://grove.opencraft.com/).)
-   * Where possible, we try to configure these systems to **auto-detect** newly deployed Open edX instances and adapt to them automatically; where that isn't possible, Tutor plugins are used so that the instances self-register or self-provision the shared resources as needed.
-3. [Tutor](https://docs.tutor.overhang.io/) is used to build the container images that will be deployed onto the cluster.
-   * This project's Tutor plugin is required to make the images compatible with the shared resources deployed by the Helm chart.
-   * The
-[pod-autoscaling plugin](https://github.com/eduNEXT/tutor-contrib-pod-autoscaling) is required for autoscaling.
-   * You can use the `tutor k8s` commands directly (as documented below) or you can use a CI/CD tool like [Grove](https://grove.opencraft.com/) to deploy instances/images.
+   * Monitoring: Grafana + Prometheus via
+     [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts).
+   * Database clusters: TODO (for now we recommend provisioning managed
+     MySQL/MongoDB database clusters from your cloud provider using OpenTofu or
+     a tool like [Grove](https://grove.opencraft.com/).)
+   * Where possible, we try to configure these systems to **auto-detect** newly
+     deployed Open edX instances and adapt to them automatically; where that
+     isn't possible, Tutor plugins are used so that the instances self-register
+     or self-provision the shared resources as needed.
+3. [Tutor](https://docs.tutor.overhang.io/) is used to build the container
+   images that will be deployed onto the cluster.
+   * This project's Tutor plugin is required to make the images compatible with
+     the shared resources deployed by the Helm chart.
+   * The [pod-autoscaling plugin](https://github.com/eduNEXT/tutor-contrib-pod-autoscaling)
+     is required for autoscaling.
+   * You can use the `tutor k8s` commands directly (as documented below) or you
+     can use a CI/CD tool like [Grove](https://grove.opencraft.com/) to deploy
+     instances/images.
 
 ## FAQ
 
 ### This project aims to support many small/medium instances deployed onto a cluster; is it also suitable for deploying one really high traffic instance?
 
-Supporting one really large instance is not a core design goal, but it should work well and we may consider including this as a goal in the future. Please reach out to us or get involved with this project if you have this requirement.
+Supporting one really large instance is not a core design goal, but it should
+work well and we may consider including this as a goal in the future. Please
+reach out to us or get involved with this project if you have this requirement.
 
 ### What are the gotchas related to cert-manager?
 
-This helm chart uses [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) as a load balancer alongside [cert-manager](https://cert-manager.io/) to provide automatic SSL certificates. Because of how Helm works, the cert-manager sub-chart will be installed into the same namespace as the parent harmony chart. But if you already have cert-manager on your cluster, this will create a conflict. You should take special care not to install cert-manager twice due to it installing several non-namespaced resources. If you already installed cert-manager by different means, make sure set `cert-manager.enabled: false` for this chart.
+This helm chart uses [Traefik](https://traefik.io/traefik/) or
+[ingress-nginx](https://kubernetes.github.io/ingress-nginx/) as a load balancer
+alongside [cert-manager](https://cert-manager.io/) to provide automatic SSL
+certificates. Because of how Helm works, the cert-manager sub-chart will be
+installed into the same namespace as the parent harmony chart. But if you
+already have cert-manager on your cluster, this will create a conflict. You
+should take special care not to install cert-manager twice due to it installing
+several non-namespaced resources. If you already installed cert-manager by
+different means, make sure set `cert-manager.enabled: false` for this chart.
 
-In addition, [the cert-manager Helm charts do not install the required CRDs used by cert-manager](https://cert-manager.io/docs/installation/upgrading/#crds-managed-separately), so you will need to manually install and upgrade them to the correct version as described in the instructions below. This is due to the some limitations in the management of CRDs by Helm.
+In addition,
+[the cert-manager Helm charts do not install the required CRDs used by cert-manager](https://cert-manager.io/docs/installation/upgrading/#crds-managed-separately),
+so you will need to manually install and upgrade them to the correct version as
+described in the instructions below. This is due to the some limitations in the
+management of CRDs by Helm.
 
 ### How the autoscaling capabilities are implemented in this project?
 
-Tutor does not offer an autoscaling mechanism by default. This is a critical feature when your application starts to
-receive more and more traffic. Kubernetes offers two main autoscaling methods:
+Tutor does not offer an autoscaling mechanism by default. This is a critical
+feature when your application starts to receive more and more traffic.
+Kubernetes offers two main autoscaling methods:
 
-* **Pod-based scaling**: This mechanism consists of the creation and adjustment of new pods to cover growing workloads.
-Here we can mention tools like
-[**Horizontal Pod autoscaler (HPA)**](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
-and [**Vertical pod autoscaler (VPA)**](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler).
-The first consist of automatically increasing or decreasing the number of pods in response to a workload's metric
-consumption (generally CPU and memory), and the second one aims to stabilize the consumption and resources of every pod
-by providing suggestions on the best configuration for a workload based on historical resource usage measurements. Both
-of them are meant to be applied over Kubernetes Deployment instances.
+* **Pod-based scaling**: This mechanism consists of the creation and adjustment
+  of new pods to cover growing workloads.
+  Here we can mention tools like
+  [**Horizontal Pod autoscaler (HPA)**](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+  and
+  [**Vertical pod autoscaler (VPA)**](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler).
+  The first consist of automatically increasing or decreasing the number of pods
+  in response to a workload's metric consumption (generally CPU and memory), and
+  the second one aims to stabilize the consumption and resources of every pod by
+  providing suggestions on the best configuration for a workload based on
+  historical resource usage measurements. Both of them are meant to be applied
+  over Kubernetes Deployment instances.
 
-* **Node-based scaling:** This mechanism allows the addition of new NODES to the Kubernetes cluster so compute resources
-are guaranteed to schedule new incoming workloads. Tools worth mentioning in this category are
-[**cluster-autoscaler (CA)**](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) and
-[Karpenter](https://karpenter.sh/).
+* **Node-based scaling:** This mechanism allows the addition of new NODES to the
+  Kubernetes cluster so compute resources
+  are guaranteed to schedule new incoming workloads. Tools worth mentioning in
+  this category are
+  [**cluster-autoscaler (CA)**](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler)
+  and [Karpenter](https://karpenter.sh/).
 
-For the scope of this project, the focus will be in the **pod-based scaling** mechanisms since Node-based scaling tools
-require configuration which is external to the cluster and this is out of the scope for this Helm chart for now.
+For the scope of this project, the focus will be in the **pod-based scaling**
+mechanisms since Node-based scaling tools require configuration which is
+external to the cluster and this is out of the scope for this Helm chart for
+now.
 
-The approach will be to use pod autoscaling on each environment separately (assuming there are installations on different
-namespaces) following the steps below:
+The approach will be to use pod autoscaling on each environment separately
+(assuming there are installations on different namespaces) following the steps
+below:
 
-1. **Install the global dependencies**: this Helm chart offers the option of installing the dependencies required to
-get HPA and VPA working (they are included as subcharts). These are the Helm charts for **metrics-server** and **VPA**.
-By default these dependencies are not installed, however you can enable them via the Helm chart values if they aren't
-still present in your cluster.
+1. **Install the global dependencies**: this Helm chart offers the option of
+   installing the dependencies required to
+   get HPA and VPA working (they are included as subcharts). These are the Helm
+   charts for **metrics-server** and **VPA**. By default these dependencies are not
+   installed, however you can enable them via the Helm chart values if they aren't
+   still present in your cluster.
 2. **Enable the pod-autoscaling plugin per environment**: the
-[pod-autoscaling plugin](https://github.com/eduNEXT/tutor-contrib-pod-autoscaling) enables the implementation of HPA and
-VPA to start scaling an installation workloads. Variables for the plugin configuration are documented there.
+   [pod-autoscaling plugin](https://github.com/eduNEXT/tutor-contrib-pod-autoscaling)
+   enables the implementation of HPA and VPA to start scaling an installation
+   workloads. Variables for the plugin configuration are documented there.
 
 #### Node-autoscaling with Karpenter in EKS Clusters
 
-This section provides a guide on how to install and configure [Karpenter](https://karpenter.sh/) in a EKS cluster. We'll use
-infrastructure examples included in this repo for such purposes.
+This section provides a guide on how to install and configure
+[Karpenter](https://karpenter.sh/) in a EKS cluster. We'll use infrastructure
+examples included in this repo for such purposes.
 
 > Prerequisites:
 
@@ -99,9 +173,11 @@ infrastructure examples included in this repo for such purposes.
 * OpenTofu 1.6.x or higher
 * Helm
 
-1. Clone this repository and navigate to `./infra-examples/aws`. You'll find OpenTofu modules for `vpc` and `k8s-cluster`
-resources. Proceed creating the `vpc` resources first, followed by the `k8s-cluster` resources. Make sure to have the target
-AWS account ID available, and then execute the following commands on every folder:
+1. Clone this repository and navigate to `./infra-examples/aws`. You'll find
+   OpenTofu modules for `vpc` and `k8s-cluster`
+resources. Proceed creating the `vpc` resources first, followed by the
+`k8s-cluster` resources. Make sure to have the target AWS account ID available,
+and then execute the following commands on every folder:
 
    ```sh
    tofu init
@@ -109,9 +185,11 @@ AWS account ID available, and then execute the following commands on every folde
    tofu apply -auto-approve
    ```
 
-   It will create an EKS cluster in the new VPC. Required Karpenter resources will also be created.
+   It will create an EKS cluster in the new VPC. Required Karpenter resources will
+   also be created.
 
-2. Once the `k8s-cluster` is created, run the `tofu output` command on that module and copy the following output variables:
+2. Once the `k8s-cluster` is created, run the `tofu output` command on that
+   module and copy the following output variables:
 
    * cluster_name
    * karpenter_irsa_role_arn
@@ -119,13 +197,16 @@ AWS account ID available, and then execute the following commands on every folde
 
    These variables will be required in the next steps.
 
-3. Karpenter is a dependency of the harmony chart that can be enabled or disabled. To include Karpenter in the Harmony Chart,
+3. Karpenter is a dependency of the harmony chart that can be enabled or
+   disabled. To include Karpenter in the Harmony Chart,
 **it is crucial** to configure these variables in your `values.yaml` file:
 
    * `karpenter.enabled`: true
-   * `karpenter.serviceAccount.annotations.eks\.amazonaws\.com/role-arn`: "<`karpenter_irsa_role_arn` value from module>"
-   * `karpenter.settings.aws.defaultInstanceProfile`: "<`karpenter_instance_profile_name` value from module>"
-   * `karpenter.settings.aws.clusterName`:  "<`cluster_name` value from module>"
+   * `karpenter.serviceAccount.annotations.eks\.amazonaws\.com/role-arn`:
+     "<`karpenter_irsa_role_arn` value from module>"
+   * `karpenter.settings.aws.defaultInstanceProfile`:
+     "<`karpenter_instance_profile_name` value from module>"
+   * `karpenter.settings.aws.clusterName`: "<`cluster_name` value from module>"
 
    Find below an example of the Karpenter section in the `values.yaml` file:
 
@@ -147,18 +228,40 @@ AWS account ID available, and then execute the following commands on every folde
             defaultInstanceProfile: "<karpenter_instance_profile_name>"
    ```
 
-4. Now, install the Harmony Chart in the new EKS cluster using [these instructions](#usage-instructions). This will provide a
-very basic Karpenter configuration with one [provisioner](https://karpenter.sh/docs/concepts/provisioners/) and one
-[node template](https://karpenter.sh/docs/concepts/node-templates/). Please refer to the official documentation to
-get further details.
+4. Now, install the Harmony Chart in the new EKS cluster using
+   [these instructions](#usage-instructions). This will provide a
+   very basic Karpenter configuration with one
+   [provisioner](https://karpenter.sh/docs/concepts/provisioners/) and one
+   [node template](https://karpenter.sh/docs/concepts/node-templates/). Please
+   refer to the official documentation to get further details.
 
-> **NOTE:**
-> This Karpenter installation does not support multiple provisioners or node templates for now.
+> [!NOTE]
+> This Karpenter installation does not support multiple provisioners
+> or node templates for now.
 
 5. To test Karpenter, you can proceed with the instructions included in the
 [official documentation](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#first-use).
 
-<br><br><br>
+### Ingress NGINX deprecation
+
+Following the announcement of Ingress NGINX retirement, [the Harmony project
+decided](./docs/decisions/0000-replacement-for-ingress.md) to
+adopt the Traefik Ingress controllers as an alternative.
+
+Release `0.11.0` of Harmony will include the Traefik official helm chart as a
+dependency alongside Ingress NGINX. Operators are encouraged to start migrating
+as soon as possible. Release `0.12.0` will remove all support for Ingress NGINX.
+
+Migration effort will vary depending on how much reliance on NGINX custom
+annotations the operator has. Traefik provides a compatibility layer that will
+register all the Ingress objects associated with the NGINX ingress class with
+support for a subset of custom annotations. Any behavior that goes beyond the
+annotations implemented in the compatibility layer must be rewritten as a
+Traefik middleware CRD.
+
+The [official Traefik migration
+guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/) serves as a
+good starting point to start building a migration plan.
 
 ## Usage Instructions
 
@@ -166,14 +269,18 @@ get further details.
 
 #### Option 1a: Setting up Harmony Chart on a cloud-hosted Kubernetes Cluster (recommended)
 
-For this recommended approach, you need to have a Kubernetes cluster in the cloud **with at least 12GB of usable
-memory** (that's enough to test 2 Open edX instances).
+For this recommended approach, you need to have a Kubernetes cluster in the
+cloud **with at least 12GB of usable memory** (that's enough to test 2 Open edX
+instances).
 
-1. Make sure you can access the cluster from your machine: run `kubectl cluster-info` and make sure it displays some
-   information about the cluster (e.g. two URLs).
-2. Copy `values-example.yaml` to a new `values.yaml` file and edit it to put in your email address and customize
-   other settings. The email address is required for Lets Encrypt to issue HTTPS certificates. It is not shared
-   with anyone else. For a full configuration reference, see the `charts/harmony-chart/values.yaml` file.
+1. Make sure you can access the cluster from your machine: run
+   `kubectl cluster-info` and make sure it displays some information about the
+   cluster (e.g. two URLs).
+2. Copy `values-example.yaml` to a new `values.yaml` file and edit it to put in
+   your email address and customize other settings. The email address is
+   required for Lets Encrypt to issue HTTPS certificates. It is not shared with
+   anyone else. For a full configuration reference, see the
+   `charts/harmony-chart/values.yaml` file.
 3. Install [Helm](https://helm.sh/) if you don't have it already.
 4. Add the Harmony Helm repository:
 
@@ -188,15 +295,17 @@ memory** (that's enough to test 2 Open edX instances).
    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.crds.yaml --namespace=harmony
    ```
 
-   You can check the version of cert-manager that is going to be installed by the chart by checking the corresponding
-   line in the `charts/harmony-chart/Chart.yaml` file.
+   You can check the version of cert-manager that is going to be installed by
+   the chart by checking the corresponding line in the
+   `charts/harmony-chart/Chart.yaml` file.
 6. Install the Harmony chart by running:
 
    ```shell
    helm install harmony --namespace harmony --create-namespace -f values.yaml openedx-harmony/harmony-chart
    ```
 
-Note: in the future, if you apply changes to `values.yaml`, please run this command to update the deployment of the chart:
+Note: in the future, if you apply changes to `values.yaml`, please run this
+command to update the deployment of the chart:
 
 ```shell
 helm upgrade harmony --namespace harmony -f values.yaml openedx-harmony/harmony-chart
@@ -204,13 +313,17 @@ helm upgrade harmony --namespace harmony -f values.yaml openedx-harmony/harmony-
 
 #### Option 1b: Setting up Harmony Chart locally on Minikube
 
-*Note: if possible, it's preferred to use a cloud-hosted cluster instead (see previous section). But if you don't have a
-cluster available in the cloud, you can use minikube to try this out locally. The minikube version does not support
+*Note: if possible, it's preferred to use a cloud-hosted cluster instead (see
+previous section). But if you don't have a cluster available in the cloud, you
+can use minikube to try this out locally. The minikube version does not support
 HTTPS and is more complicated due to the need to use tunnelling.*
 
-1. First, [install `minikube`](https://minikube.sigs.k8s.io/docs/start/) if you don't have it already.
-2. Run `minikube start` (you can also use `minikube dashboard` to access the Kubernetes dashboard).
-3. Add the Helm repository and install the Harmony chart using the `values-minikube.yaml` file as configuration:
+1. First, [install `minikube`](https://minikube.sigs.k8s.io/docs/start/) if you
+   don't have it already.
+2. Run `minikube start` (you can also use `minikube dashboard` to access the
+   Kubernetes dashboard).
+3. Add the Helm repository and install the Harmony chart using the
+   `values-minikube.yaml` file as configuration:
 
    ```shell
    helm repo add openedx-harmony https://openedx.github.io/openedx-k8s-harmony
@@ -218,34 +331,43 @@ HTTPS and is more complicated due to the need to use tunnelling.*
    helm install harmony --namespace harmony --create-namespace -f values-minikube.yaml openedx-harmony/harmony-chart
    ```
 
-4. Run `minikube tunnel` (you may need to enter a password), and then you should be able to access the cluster (see
-   "External IP" below). If this approach is not working, an alternative is to run\
-   `minikube service harmony-ingress-nginx-controller -n harmony`\
-   and then go to the URL it says, e.g. `http://127.0.0.1:52806` plus `/cluster-echo-test`
-   (e.g. `http://127.0.0.1:52806/cluster-echo-test`)
-5. In this case, skip step 2 ("Get the external IP") and use `127.0.0.1` as the external IP. You will need to remember
-   to include the port numbers shown above when accessing the instances.
+4. Run `minikube tunnel` (you may need to enter a password), and then you should
+   be able to access the cluster (see "External IP" below). If this approach is
+   not working, an alternative is to run\
+   `minikube service harmony-traefik -n harmony` (or
+   `harmony-ingress-nginx-controller` if using ingress-nginx)\
+   and then go to the URL it says, e.g. `http://127.0.0.1:52806` plus
+   `/cluster-echo-test` (e.g. `http://127.0.0.1:52806/cluster-echo-test`)
+5. In this case, skip step 2 ("Get the external IP") and use `127.0.0.1` as the
+   external IP. You will need to remember to include the port numbers shown
+   above when accessing the instances.
 
 ### Step 2: Get the external IP
 
-The [ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) is used to automatically set up an HTTPS
-reverse proxy for each Open edX instance as it gets deployed onto the cluster. There is just one load balancer with a
-single external IP for all the instances on the cluster. To get its IP, use:
+The [Traefik Ingress controller](https://traefik.io/traefik/) (and
+[ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/)) is used
+to automatically set up an HTTPS reverse proxy for each Open edX instance as it
+gets deployed onto the cluster. There is just one load balancer with a single
+external IP for all the instances on the cluster. To get its IP, use:
 
 ```shell
-kubectl get svc -n harmony harmony-ingress-nginx-controller
+kubectl get svc -n harmony harmony-traefik # or harmony-ingress-nginx-controller
 ```
 
-To test that your load balancer is working, go to `http://<the external ip>/cluster-echo-test` .
-You may need to ignore the HTTPS warnings, but then you should see a response with some basic JSON output.
+To test that your load balancer is working, go to
+`http://<the external ip>/cluster-echo-test`. You may need to ignore the HTTPS
+warnings, but then you should see a response with some basic JSON output.
 
 ### Step 3: Deploying an Open edX instance using Tutor
 
-Important: First, get the load balancer's IP (see "external IP" above), and set the DNS records for the instance you
-want to create to be pointing to the load balancer (Usually if you want the LMS at `lms.example.com`, you'll need to set
-two A records for `lms.example.com` and `*.lms.example.com`, pointing to the external IP from the load balancer).
+Important: First, get the load balancer's IP (see "external IP" above), and set
+the DNS records for the instance you want to create to be pointing to the load
+balancer (Usually if you want the LMS at `lms.example.com`, you'll need to set
+two A records for `lms.example.com` and `*.lms.example.com`, pointing to the
+external IP from the load balancer).
 
-You also will need to have the tutor-contrib-harmony-plugin installed into Tutor:
+You also will need to have the tutor-contrib-harmony-plugin installed into
+Tutor:
 
 ```shell
 pip install -e 'git+https://github.com/openedx/openedx-k8s-harmony.git#egg=tutor-contrib-harmony-plugin&subdirectory=tutor-contrib-harmony-plugin'
@@ -267,10 +389,12 @@ tutor k8s start
 tutor k8s init
 ```
 
-Note that the `init` command may take quite a long time to complete. Use the commands that Tutor says ("To view the logs
-from this job, run:") in a separate terminal in order to monitor the status.
+Note that the `init` command may take quite a long time to complete. Use the
+commands that Tutor says ("To view the logs from this job, run:") in a separate
+terminal in order to monitor the status.
 
-**You can repeat step 3 many times to install multiple instances onto the cluster.**
+**You can repeat step 3 many times to install multiple instances onto the
+cluster.**
 
 <br><br><br>
 
@@ -286,42 +410,51 @@ You have three options to run Meilisearch for Open edX:
 
 #### Default installation
 
-By default, Tutor will setup a Meilisearch instance inside the K8s cluster.
-If you have multiple sites in your cluster, each one will have its own Meilisearch pod.
-Just leave all Meilisearch settings by default.
+By default, Tutor will setup a Meilisearch instance inside the K8s cluster. If
+you have multiple sites in your cluster, each one will have its own Meilisearch
+pod. Just leave all Meilisearch settings by default.
 
 #### Public Meilisearch server
 
-If you want to use [Meilisearch Cloud](https://www.meilisearch.com/cloud) or you have your own Meilisarch
-internet-facing server, set `RUN_MEILISEARCH=false` and `MEILISEARCH_PUBLIC_URL` to the public address 
-(e.g. https://ms-yourinstanceid.meilisearch.io). The server must be accessible from Internet and must 
-support HTTPS with its own certificates.
+If you want to use [Meilisearch Cloud](https://www.meilisearch.com/cloud) or you
+have your own Meilisarch internet-facing server, set `RUN_MEILISEARCH=false` and
+`MEILISEARCH_PUBLIC_URL` to the public address (e.g.
+<https://ms-yourinstanceid.meilisearch.io>). The server must be accessible from
+Internet and must support HTTPS with its own certificates.
 
 Make sure to set `MEILISEARCH_INDEX_PREFIX` to a value different for each site.
 
 #### Private Meilisearch server
 
-You can [install Meilisearch](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch) 
-in a private server. In this case, make sure that the cluster has routes and security rules
-that allow traffic from and to the server (by default Meilisearch listens to port 7700).
-In this case, set `RUN_MEILISEARCH=false` and `MEILISEARCH_URL` with the internal name or IP address of the Meilisearch
-server, including port number (e.g., http://10.1.2.3:7700). 
+You can
+[install Meilisearch](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch)
+in a private server. In this case, make sure that the cluster has routes and
+security rules that allow traffic from and to the server (by default Meilisearch
+listens to port 7700). In this case, set `RUN_MEILISEARCH=false` and
+`MEILISEARCH_URL` with the internal name or IP address of the Meilisearch
+server, including port number (e.g., <http://10.1.2.3:7700>).
 
-The server doesn't need SSL certificates; they will be managed by cert-manager. 
-Just leave MEILISEARCH_PUBLIC_URL unset, which will be https://meilisearch.{{LMS_HOST}} by default.
+The server doesn't need SSL certificates; they will be managed by cert-manager.
+Just leave MEILISEARCH_PUBLIC_URL unset, which will be
+<https://meilisearch.{{LMS_HOST}}> by default.
 
 Make sure to set `MEILISEARCH_INDEX_PREFIX` to a value different for each site.
 
 ### Multi-tenant Elasticsearch (Deprecated)
 
-Note: this is not required nor recommended for "Sumac" and newer versions of Open edX, which use Meilisearch instead of Elasticsearch.
+Note: this is not required nor recommended for "Sumac" and newer versions of
+Open edX, which use Meilisearch instead of Elasticsearch.
 
-For "Redwood" versions of Open edX, Tutor creates an Elasticsearch pod as part of the Kubernetes deployment. Depending on the number of instances, memory
-and CPU use can be lowered by running a central ES cluster instead of an ES pod for every instance.
+For "Redwood" versions of Open edX, Tutor creates an Elasticsearch pod as part
+of the Kubernetes deployment. Depending on the number of instances, memory and
+CPU use can be lowered by running a central ES cluster instead of an ES pod for
+every instance.
 
-To enable set `elasticsearch.enabled=true` in your `values.yaml` and deploy the chart.
+To enable set `elasticsearch.enabled=true` in your `values.yaml` and deploy the
+chart.
 
-For each instance you would like to enable this on, set the configuration values in the respective `config.yml`:
+For each instance you would like to enable this on, set the configuration values
+in the respective `config.yml`:
 
 ```yaml
 RUN_ELASTICSEARCH: false
@@ -330,17 +463,23 @@ K8S_HARMONY_SEARCH_CLUSTER_HTTP_AUTH: instance-name:desired-password
 K8S_HARMONY_SEARCH_CLUSTER_INDEX_PREFIX: prefix-
 ```
 
-If the `K8S_HARMONY_SEARCH_CLUSTER_HTTP_AUTH` or `K8S_HARMONY_SEARCH_CLUSTER_INDEX_PREFIX` is not set, the settings are
-populated with random value to ensure uniqueness.
+If the `K8S_HARMONY_SEARCH_CLUSTER_HTTP_AUTH` or
+`K8S_HARMONY_SEARCH_CLUSTER_INDEX_PREFIX` is not set, the settings are populated
+with random value to ensure uniqueness.
 
 * Create the user on the cluster with `tutor harmony create-elasticsearch-user`.
-* Copy the Elasticsearch CA certificate to the instance's namespace where `$INSTANCE_NAMESPACE` is where the instance is installed in. The `$HARMONY_NAMESPACE` should be set to the namespace where the Harmony is installed to.
+* Copy the Elasticsearch CA certificate to the instance's namespace where
+  `$INSTANCE_NAMESPACE` is where the instance is installed in. The
+  `$HARMONY_NAMESPACE` should be set to the namespace where the Harmony is
+  installed to.
+
   ```shell
   kubectl get secret "search-cluster-certificates-elasticsearch" -n "$HARMONY_NAMESPACE" -o "yaml" | \
       grep -v '^\s*namespace:\s' | \
       sed s/-elasticsearch//g |\
       kubectl apply -n "$INSTANCE_NAMESPACE" --force -f -
   ```
+
 * Rebuild your Open edX image `tutor images build openedx`.
 * Finally, redeploy your changes: `tutor k8s start && tutor k8s init`.
 
@@ -352,9 +491,12 @@ Just run `helm uninstall --namespace harmony harmony` to uninstall this.
 
 ### How to create a cluster for testing on DigitalOcean
 
-If you use DigitalOcean, you can use OpenTofu to quickly spin up a cluster, try this out, then shut it down again.
+If you use DigitalOcean, you can use OpenTofu to quickly spin up a cluster, try
+this out, then shut it down again.
 
-Here's how. First, put the following into `infra-examples/digitalocean/secrets.auto.tfvars` including a valid DigitalOcean access token:
+Here's how. First, put the following into
+`infra-examples/digitalocean/secrets.auto.tfvars` including a valid DigitalOcean
+access token:
 
 ```conf
 cluster_name = "harmony-test"
@@ -376,8 +518,10 @@ up everything.
 
 ## Appendix C: how to create a cluster for testing on AWS
 
-Similarly, if you use AWS, you can use OpenTofu to spin up a cluster, try this out, then shut it down again.
-Here's how. First, put the following into `infra-examples/aws/vpc/secrets.auto.tfvars` and `infra-examples/aws/k8s-cluster/secrets.auto.tfvars`:
+Similarly, if you use AWS, you can use OpenTofu to spin up a cluster, try this
+out, then shut it down again. Here's how. First, put the following into
+`infra-examples/aws/vpc/secrets.auto.tfvars` and
+`infra-examples/aws/k8s-cluster/secrets.auto.tfvars`:
 
    ```terraform
    account_id  = "012345678912"
@@ -400,4 +544,5 @@ Then run:
    aws eks --region us-east-1 update-kubeconfig --name tutor-multi-test --alias tutor-multi-test
    ```
 
-Then follow steps 1-4 above. When you're done, run `tofu destroy` in both the `aws` and `k8s-cluster` modules to clean up everything.
+Then follow steps 1-4 above. When you're done, run `tofu destroy` in both the
+`aws` and `k8s-cluster` modules to clean up everything.

--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -1,7 +1,10 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.14.1
+  version: 4.15.1
+- name: traefik
+  repository: oci://ghcr.io/traefik/helm
+  version: 40.0.1
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.19.3
@@ -32,5 +35,5 @@ dependencies:
 - name: vector
   repository: https://helm.vector.dev
   version: 0.50.0
-digest: sha256:0c9ece5b8130e4536ab5357e0b08dfdb1448365138796990a6b3ff7957d64f02
-generated: "2026-02-19T17:01:07.30458+04:00"
+digest: sha256:924fbea9d7fe0adb0eea843f690af91c83aeb6b2937c3ed93cd12536e8ad6253
+generated: "2026-05-12T14:21:48.81778687-04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
@@ -17,9 +17,14 @@ dependencies:
   # This is just info for the "helm dependency update" command, which will update the ./charts/ directory when run, using
   # this information.
   - name: ingress-nginx
-    version: "4.14.1"
+    version: "4.15.1"
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
+
+  - name: traefik
+    version: "40.0.1"
+    repository: oci://ghcr.io/traefik/helm
+    condition: traefik.enabled
 
   - name: cert-manager
     version: "v1.19.3"

--- a/charts/harmony-chart/templates/NOTES.txt
+++ b/charts/harmony-chart/templates/NOTES.txt
@@ -1,11 +1,15 @@
 
 Your harmony cluster is now ready to use!
 
-An NGINX load balancer routes all HTTP/HTTPS traffic into the cluster to each
+An NGINX or Traefik load balancer routes all HTTP/HTTPS traffic into the cluster to each
 Open edX instance. Even before you deploy any Open edX instances, you can test
 that the load balancer is working. First, get its external IP using
 
+{{- if index .Values "traefik" "enabled" }}
+    kubectl get svc -n {{ .Release.Namespace }} harmony-traefik
+{{- else }}
     kubectl get svc -n {{ .Release.Namespace }} harmony-ingress-nginx-controller
+{{- end }}
 
 Next, go to http://{{ .Values.clusterDomain }}/cluster-echo-test and make sure you get
 a JSON response.
@@ -22,35 +26,12 @@ expose it.
 
 To connect to the dashboard, start port-forwarding with the following command:
 
-    kubectl -n harmony port-forward svc/harmony-nginx-controller 8443:443
+{{- if index .Values "traefik" "enabled" }}
+    kubectl -n {{ .Release.Namespace }} port-forward svc/harmony-traefik 8443:443
+{{- else }}
+    kubectl -n {{ .Release.Namespace }} port-forward svc/harmony-ingress-nginx-controller 8443:443
+{{- end }}
 
 Now you can connect to https://localhost:8443. The certificate is self-signed by
 the cluster.
 {{- end }}
-
-{{- /*
-
-Examples of more stuff that can be in a NOTES file:
-
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "harmony-chart.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "harmony-chart.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "harmony-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "harmony-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
-*/}}

--- a/charts/harmony-chart/templates/echo.yaml
+++ b/charts/harmony-chart/templates/echo.yaml
@@ -1,6 +1,8 @@
-# This service, which is always enabled, allows you to do basic health checks of your cluster and the Ingress Controller
-# Service by accessing /cluster-echo-test via HTTP on any hostname associated with your cluster.
-{{- if index .Values "ingress-nginx" "enabled" }}
+# This service, which is always enabled, allows you to do basic health checks
+# of your cluster and the Ingress Controller
+# Service by accessing /cluster-echo-test via HTTP on any hostname associated
+# with your cluster.
+{{- if or (index .Values "ingress-nginx" "enabled") (index .Values "traefik" "enabled") }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -46,7 +48,6 @@ kind: Ingress
 metadata:
   name: cluster-echo-test
 spec:
-  ingressClassName: {{ (index .Values "ingress-nginx" "controller" "ingressClass") }}
   rules:
   - host: {{ .Values.clusterDomain }}
     http:

--- a/charts/harmony-chart/templates/issuer.yaml
+++ b/charts/harmony-chart/templates/issuer.yaml
@@ -14,5 +14,9 @@ spec:
     solvers:
     - http01:
         ingress:
-          class:  {{ index .Values "ingress-nginx" "controller" "ingressClass" }}
+          {{- if index .Values "ingress-nginx" "enabled" -}}
+          class: {{ (index .Values "ingress-nginx" "controller" "ingressClass") }}
+          {{- else if .Values.traefik.enabled -}}
+          class: {{ .Values.traefik.ingressClass.name }}
+          {{- end -}}
 {{ end }}

--- a/charts/harmony-chart/values.yaml
+++ b/charts/harmony-chart/values.yaml
@@ -12,6 +12,18 @@ ingress-nginx:
   # Use ingress-nginx as a default controller.
   enabled: true
 
+traefik:
+  # Enable the traefik ingress controller
+  enabled: false
+  ingressClass:
+    isDefaultClass: false
+    name: "traefik"
+  providers: 
+    kubernetesIngressNginx: 
+      enabled: true
+      ingressClassByName: true
+
+
 cert-manager:
   # Use cert-manager as a default certificate controller.
   enabled: true

--- a/docs/decisions/0000-replacement-for-ingress.md
+++ b/docs/decisions/0000-replacement-for-ingress.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Draft** *2026-02-23*
+**Accepted** *2026-03-11*
 
 ## Context
 

--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/plugin.py
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/plugin.py
@@ -25,7 +25,7 @@ def is_plugin_loaded(plugin_name: str) -> bool:
 config = {
     "defaults": {
         "VERSION": __version__,
-        # This plugin assumes you are using ingress-nginx as an ingress controller to provide
+        # This plugin assumes you are using Traefik (or ingress-nginx) as an ingress controller to provide
         # you with a central load balancer. The standard Ingress object uses annotations to
         # trigger the generation of certificates using cert-manager.
         # See: https://cert-manager.io/docs/usage/ingress/#supported-annotations


### PR DESCRIPTION
This is a first step towards the migration off Ingress NGINX. It mainly adds the Traefik chart dependency, adjust hardcoded values that depend in Ingress NGINX and updates the readme.

I ran a formatter through the readme, so there's a lot of changes. I recommend using the display rich diff option: 
<img width="578" height="147" alt="image" src="https://github.com/user-attachments/assets/3f1b9c60-26db-466b-9bac-bd65d438fd08" />
