### PR TITLE
fix: revise kustomization patches for modern tutor

### DIFF
--- a/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/kustomization-patches
+++ b/tutor-contrib-harmony-plugin/tutor_k8s_harmony_plugin/patches/kustomization-patches
@@ -14,8 +14,6 @@
 {%- if is_plugin_loaded("forum") %}
   {%- set VOLUMELESS = VOLUMELESS + ["forum", "forum-job"] %}
 {% endif %}
-
-patches:
 - path: plugins/k8s_harmony/k8s/deployment-revision-history.yaml
   target:
     kind: Deployment


### PR DESCRIPTION

## Description

This pull request fixes patches to the Kustomize file. Currently, harmony uses the `kustomize` patch, which places content at the bottom of the `kustomize.yml` file. However, tutor now supports adding entries to the `patches` key in a `kustomize.yml` file directly. If existing patches are added by other plugins, harmony clobbers all of them by redefining the `patches` key. This change makes harmony a better citizen by placing its patches within the new patch filter rather than appending at the end.

## Supporting information

Internal ticket: https://tasks.opencraft.com/browse/BB-10959

## Testing instructions

1. Install and enable harmony in a tutor project.
2. Install another plugin that uses Kustomize patches and set it up so it will. Take this PR/branch for tutor-contrib-grove as an example: https://gitlab.com/opencraft/dev/tutor-contrib-grove/-/merge_requests/134
3. Save the configuration with `tutor config save`
4. Check the `kustomize.yml` file. Notice that the `patches` key is redefined and clobbers the other settings.
5. Reinstall with this branch
6. Run `tutor config save`
7. See that the patches are now in... harmony :)