### PR TITLE
feat(chart): make ClusterIssuer configurable and ingress-class aware

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -35,5 +35,5 @@ dependencies:
 - name: vector
   repository: https://helm.vector.dev
   version: 0.50.0
-digest: sha256:beb4ce4eaf308c34c1a09b249056ac239c0e91d511a7c2f3182bb1c208fac6c2
-generated: "2026-07-06T19:58:47.601688732-04:00"
+digest: sha256:211521a7d8060bfba054f74f55003a71260ba041d26b262960535b2eda2dd75a
+generated: "2026-08-05T15:25:46.00651168-04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.0
+version: 0.12.1
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.

--- a/charts/harmony-chart/templates/echo.yaml
+++ b/charts/harmony-chart/templates/echo.yaml
@@ -49,8 +49,7 @@ metadata:
   name: cluster-echo-test
 spec:
   rules:
-  - host: {{ .Values.clusterDomain }}
-    http:
+  - http:
       paths:
       - path: /cluster-echo-test
         pathType: Prefix
@@ -59,4 +58,7 @@ spec:
             name: cluster-echo-service
             port:
               number: 8080
+    {{- if .Values.clusterDomain }}
+    host: {{ .Values.clusterDomain }}
+    {{- end  }}
 {{- end }}

--- a/charts/harmony-chart/templates/issuer.yaml
+++ b/charts/harmony-chart/templates/issuer.yaml
@@ -1,4 +1,4 @@
-{{ if index .Values "cert-manager" "enabled" }}
+{{ if and (index .Values "cert-manager" "enabled") .Values.clusterIssuer.enabled }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -14,9 +14,13 @@ spec:
     solvers:
     - http01:
         ingress:
-          {{- if index .Values "ingress-nginx" "enabled" -}}
-          class: {{ (index .Values "ingress-nginx" "controller" "ingressClass") }}
-          {{- else if .Values.traefik.enabled -}}
-          class: {{ .Values.traefik.ingressClass.name }}
-          {{- end -}}
+          {{- if .Values.clusterIssuer.ingressClass }}
+          class: {{ .Values.clusterIssuer.ingressClass }}
+          {{- else if index .Values "ingress-nginx" "enabled" }}
+          class: {{ index .Values "ingress-nginx" "controller" "ingressClass" | default "nginx" }}
+          {{- else if .Values.traefik.enabled }}
+          class: {{ .Values.traefik.ingressClass.name | default "traefik" }}
+          {{- else }}
+          class: nginx
+          {{- end }}
 {{ end }}

--- a/charts/harmony-chart/values.yaml
+++ b/charts/harmony-chart/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-clusterDomain: "*"
+clusterDomain: null
 
 # Email address used for receiving Let's encrypt notifications if cert-manager
 # is enabled.
@@ -18,8 +18,8 @@ traefik:
   ingressClass:
     isDefaultClass: false
     name: "traefik"
-  providers: 
-    kubernetesIngressNginx: 
+  providers:
+    kubernetesIngressNGINX:
       enabled: true
       ingressClassByName: true
 
@@ -28,6 +28,12 @@ cert-manager:
   # Use cert-manager as a default certificate controller.
   enabled: true
   installCRDs: false
+
+clusterIssuer:
+  # Whether to create the harmony-letsencrypt-global ClusterIssuer.
+  enabled: true
+  # Custom ingress class used by the Let's Encrypt HTTP01 solver.
+  ingressClass: ""
 
 # Configuration for the metrics server chart
 metricsserver:
@@ -244,11 +250,11 @@ karpenter:
     name: "default"
 
 # Prometheus stack
-#   
+#
 # If no storage is defined, the Prometheus and Grafana data is stored on
 # empheral storage. You can find more information about storages in the
 # Prometheus operator user guides: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/storage.md
-# 
+#
 # - To make Grafana persistent, you may want to set Grafana storage as shown in https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L999-L1009
 # - To set Prometheus storage, you can see the example storage spec at https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L3557-L3570
 prometheusstack:


### PR DESCRIPTION
Add a `clusterIssuer` values section so the
`harmony-letsencrypt-global` ClusterIssuer can be toggled and its ACME HTTP01 ingress class can be customized.

- Fix the Traefik provider key casing from `kubernetesIngressNginx` to `kubernetesIngressNGINX` so it validates against the Traefik sub-chart schema.