### PR TITLE
feat(tutor-contrib-harmony-plugin): support verawood

### DIFF
--- a/tutor-contrib-harmony-plugin/pyproject.toml
+++ b/tutor-contrib-harmony-plugin/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "tutor>=17.0.0,<22.0.0",
+  "tutor>=17.0.0,<23.0.0",
 ]
 
 [project.entry-points."tutor.plugin.v1"]
@@ -41,7 +41,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
 strict-naming = false
-include = [ 
+include = [
     "tutor_k8s_harmony_plugin",
 ]
 exclude = ["tests*"]


### PR DESCRIPTION
## Description

Just bumping the Tutor version so it can be installed in a verawood instance. Nothing else seems amiss.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-10943

## Testing instructions

- use this with an instance deployment on verawood
- verify everything works fine. Vague, but I'm not sure what specifically to test. I used this revision with instances deployed with verawood and the deployment succeeded, and the instances seemed fine with spot checks.