### PR TITLE
chore(deps): bump version of Kube prometheus stack to 88.2.0

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 1.0.8
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 81.0.1
+  version: 88.2.0
 - name: headlamp
   repository: https://kubernetes-sigs.github.io/headlamp/
   version: 0.43.0
@@ -35,5 +35,5 @@ dependencies:
 - name: vector
   repository: https://helm.vector.dev
   version: 0.50.0
-digest: sha256:211521a7d8060bfba054f74f55003a71260ba041d26b262960535b2eda2dd75a
-generated: "2026-08-05T15:25:46.00651168-04:00"
+digest: sha256:b6213dd9db86d21f33faaedb2ef8dcd068b4d786a954be265a1d800795126969
+generated: "2026-08-13T17:01:45.503167898-04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.14.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
@@ -60,7 +60,7 @@ dependencies:
 
   - name: kube-prometheus-stack
     alias: prometheusstack
-    version: "81.0.1"
+    version: "88.2.0"
     condition: prometheusstack.enabled
     repository: https://prometheus-community.github.io/helm-charts
 


### PR DESCRIPTION
# Description

Bumps the `kube-prometheus-stack` dependency (aliased as `prometheusstack`) seven majors, from
`81.0.1` to `88.2.0`.

The diff is two files and five lines, but this is **not a routine bump**: it requires manual steps on
every cluster before the sync. Those are documented below.

## What it drags in

| Component | 81.0.1 | 88.2.0 |
|---|---|---|
| prometheus-operator (appVersion) | v0.88.0 | **v0.93.0** |
| subchart `crds` | 7.0.1 | **8.2.0** |
| subchart `grafana` | 10.5.8 (Grafana 12.3.1) | **12.10.4 (Grafana 13.1.3)** |
| subchart `kube-state-metrics` | 4.51.0 (v2.17.0) | **4.56.1 (v2.19.1)** |
| subchart `prometheus-node-exporter` | v1.10.2 | **v1.12.1-distroless** |
| k8s-sidecar | 2.2.1 | **2.10.1** |

## Chart-level compatibility

Both versions of the subchart `values.yaml` were diffed against the keys `harmony-chart` overrides.
**No key we set was removed or renamed** — all upstream changes are additive. 
So **no changes to `values.yaml` are needed in this chart**. The breaking changes are all runtime and
deployment-time, and they land on the operator.

## release notes

[kube-prometheus-stack release notes](https://prometheus-community.github.io/helm-charts/changelog/?owner=prometheus-community&repo=helm-charts&chart=kube-prometheus-stack)

## 🔴 Required before syncing

### 1. Grafana 13 changed the plugin-by-URL install syntax — In case they use it

The old `<url>;<folder>` form is no longer parsed. Grafana treats the whole URL as a plugin id and
looks it up in the catalog:

```
failed to install plugin https://github.com/.../victoriametrics-logs-datasource-v0.25.0.zip;victorialogs-datasource:
404: GET /plugins/https:/github.com/.../versions does not exist (Grafana v13.1.3 linux-amd64)
```

**The pod does not start** — `plugin.backgroundinstaller` failing brings down the whole Grafana
process; it is not a degraded datasource. The new syntax is `<plugin-id>@<version>@<url>`, and if the
plugin is in the catalog just use `<plugin-id>@<version>`.

`harmony-chart` itself ships no plugins, so this only affects operators who set `grafana.plugins` —
but for those it is a hard outage on upgrade.

## Testing

Upgraded end-to-end on an internal EKS cluster. Below are some manual steps required for the test:

### The CRDs must be applied manually, *before* the sync (using *ArgoCD*)

Even with `includeCRDs: true`, a clean sync **cannot** work. ArgoCD computes the diff for every
resource before applying any of them, so the new CRDs arriving in the same sync are too late:

```
error running server side apply in dryrun mode for resource
Alertmanager/harmony-prometheus-prometh-alertmanager:
failed to create typed patch object (monitoring.coreos.com/v1, Kind=Alertmanager):
.spec.hostNetwork: field not declared in schema
```

88.2.0 renders the Alertmanager CR with `spec.hostNetwork: false` (new in operator v0.93.0) while the
CRD in the cluster is still v0.88.0's. Chicken and egg.

Extract the CRDs from the render and apply them first:

```bash
kubectl apply --server-side --force-conflicts -f <crds.yaml>
```

`--server-side` is not optional (see the sizes above) and `--force-conflicts` is needed to take
ownership of fields currently held by Helm/ArgoCD. Then **Hard Refresh** the Application so it
recomputes the diff against the new CRDs.
