### PR TITLE
chore(deps): bump version of traefik to 41.2.0

### DIFF
--- a/charts/harmony-chart/Chart.lock
+++ b/charts/harmony-chart/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 4.15.1
 - name: traefik
   repository: oci://ghcr.io/traefik/helm
-  version: 40.0.1
+  version: 41.2.0
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.19.3
@@ -35,5 +35,5 @@ dependencies:
 - name: vector
   repository: https://helm.vector.dev
   version: 0.50.0
-digest: sha256:211521a7d8060bfba054f74f55003a71260ba041d26b262960535b2eda2dd75a
-generated: "2026-08-05T15:25:46.00651168-04:00"
+digest: sha256:0e425b9295ccde69d8b157e6922be3bf9b8867de4e2d1c31e26872a51b049555
+generated: "2026-08-14T15:56:08.469070072-04:00"

--- a/charts/harmony-chart/Chart.yaml
+++ b/charts/harmony-chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes to the chart and its
 # templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.16.0
 # This is the version number of the application being deployed. This version number should be incremented each time you
 # make changes to the application. Versions are not expected to follow Semantic Versioning. They should reflect the
 # version the application is using. It is recommended to use it with quotes.
@@ -22,7 +22,7 @@ dependencies:
     condition: ingress-nginx.enabled
 
   - name: traefik
-    version: "40.0.1"
+    version: "41.2.0"
     repository: oci://ghcr.io/traefik/helm
     condition: traefik.enabled
 


### PR DESCRIPTION
# Description

Bumps the `traefik` subchart one major, `40.0.1` → `41.2.0` (Traefik `v3.7.0` → `v3.7.10`).

## Breaking changes from the changelog

Source: <https://github.com/traefik/traefik-helm-chart/blob/master/traefik/Changelog.md>

| # | Breaking change |
|---|---|
| 1 | `logs.general` → `log`, `logs.access` → `accessLog`, filters/fields to camelCase (41.0.0) |
| 2 | `providers.file.content` from string `""` to object `{}` (41.0.0) | 
| 3 | `spec.replicas` omitted when `replicas` is `null` (41.0.0) |
| 4 | `image.registry`/`repository` default to `null` with automatic resolution (41.1.0) | 

## testing

Rendered the subchart with the chart's own Traefik values on both versions. Discounting the
`helm.sh/chart` label, the entire diff is three lines:

```diff
+ - --providers.kubernetesingressnginx.httpEntryPoint=web
+ - --providers.kubernetesingressnginx.httpsEntryPoint=websecure

- image: docker.io/traefik:v3.7.0
+ image: docker.io/traefik:v3.7.10
```

The resource inventory is identical — same 7 objects, same names, so no delete/recreate. Since the
diff covers the full render, it also rules out the two failure modes that would have been silent:

- **ClusterRole rules are unchanged.** The `align namespaced RBAC with kubernetesIngressNGINX
  namespace scoping` fix in 41.1.0 only applies with `rbac.namespaced: true`. If Traefik lost a watch
  permission it would stop seeing new Ingresses **without the pod ever failing**.
- **The Service is unchanged**, so the cloud load balancer is not recreated.

