### PR TITLE
refactor: upgrade terraform modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,13 +490,22 @@ If you use DigitalOcean, you can use OpenTofu to quickly spin up a cluster, try
 this out, then shut it down again.
 
 Here's how. First, put the following into
-`infra-examples/digitalocean/secrets.auto.tfvars` including a valid DigitalOcean
-access token:
+`infra-examples/digitalocean/secrets.auto.tfvars` (not in VCS) including a valid
+DigitalOcean access token and Spaces keys. Do not commit these values. If a
+Spaces key pair was previously committed, revoke and rotate it in the
+DigitalOcean control panel before creating a replacement.
 
 ```conf
-cluster_name = "harmony-test"
-do_token = "digital-ocean-token"
+kubernetes_cluster_name = "harmony-test"
+do_access_token         = "digital-ocean-token"
+spaces_access_id        = "spaces-access-id"
+spaces_secret_key       = "spaces-secret-key"
+environment             = "development"
+region                  = "nyc3"
 ```
+
+You can also supply the same values with `TF_VAR_do_access_token`,
+`TF_VAR_spaces_access_id`, and `TF_VAR_spaces_secret_key`.
 
 Then run:
 

--- a/infra-examples/aws/README.md
+++ b/infra-examples/aws/README.md
@@ -11,19 +11,22 @@ MongoDB Atlas does not provide an equivalent to `rds_root_username`, making it i
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=5.88 |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.62 |
+| <a name="requirement_mongodbatlas"></a> [mongodbatlas](#requirement\_mongodbatlas) | ~> 2.17 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >=5.88 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.63.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_bucket"></a> [bucket](#module\_bucket) | ../../terraform/modules/aws/s3 | n/a |
 | <a name="module_kubernetes_cluster"></a> [kubernetes\_cluster](#module\_kubernetes\_cluster) | ../../terraform/modules/aws/eks | n/a |
 | <a name="module_main_vpc"></a> [main\_vpc](#module\_main\_vpc) | ../../terraform/modules/aws/vpc | n/a |
@@ -33,14 +36,14 @@ MongoDB Atlas does not provide an equivalent to `rds_root_username`, making it i
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_docker_registry_credentials"></a> [docker\_registry\_credentials](#input\_docker\_registry\_credentials) | Image registry credentials to be added to the K8s worker nodes | `string` | `""` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The AWS project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
 | <a name="input_kubernetes_cluster_name"></a> [kubernetes\_cluster\_name](#input\_kubernetes\_cluster\_name) | Name of the Kubernetes cluster to create. | `string` | n/a | yes |

--- a/infra-examples/aws/README.md
+++ b/infra-examples/aws/README.md
@@ -4,6 +4,11 @@ This is an example implementation to create a production grade infrastructure fo
 
 ## Important notes
 
+MongoDB Atlas authentication uses a programmatic API key (`mongodbatlas_public_key` /
+`mongodbatlas_private_key` in `secrets.auto.tfvars`, or `MONGODB_ATLAS_PUBLIC_API_KEY` /
+`MONGODB_ATLAS_PRIVATE_API_KEY`). Do not pass Service Account `client_id` / `client_secret`
+values into those variables; Atlas then attempts OAuth2 and fails with `invalid_client`.
+
 Be aware that the current implementation does not support the creation of MongoDB users and S3 buckets through Tutor plugins.
 
 MongoDB Atlas does not provide an equivalent to `rds_root_username`, making it impractical to automate user creation for each instance. Consequently, while Tutor can handle MySQL database and user creation, Terraform is required (as of now) for setting up MongoDB databases and users. This approach is not ideal as it necessitates running Terraform code when adding or removing instances, which contradicts the goal of separating cluster provisioning from instance provisioning. Until a more streamlined solution, such as a plugin or automation tool, is developed, users must manually manage these resources. For now, please ensure you manually configure MongoDB users and S3 buckets to maintain a fully functional environment (either using Terraform or other methods).
@@ -48,9 +53,11 @@ MongoDB Atlas does not provide an equivalent to `rds_root_username`, making it i
 | <a name="input_environment"></a> [environment](#input\_environment) | The AWS project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
 | <a name="input_kubernetes_cluster_name"></a> [kubernetes\_cluster\_name](#input\_kubernetes\_cluster\_name) | Name of the Kubernetes cluster to create. | `string` | n/a | yes |
 | <a name="input_mongodbatlas_cidr_block"></a> [mongodbatlas\_cidr\_block](#input\_mongodbatlas\_cidr\_block) | The CIDR block in MongoDB Atlas | `string` | n/a | yes |
+| <a name="input_mongodbatlas_private_key"></a> [mongodbatlas\_private\_key](#input\_mongodbatlas\_private\_key) | MongoDB Atlas programmatic API private key | `string` | n/a | yes |
 | <a name="input_mongodbatlas_project_id"></a> [mongodbatlas\_project\_id](#input\_mongodbatlas\_project\_id) | The ID of the MongoDB Atlas project | `string` | n/a | yes |
+| <a name="input_mongodbatlas_public_key"></a> [mongodbatlas\_public\_key](#input\_mongodbatlas\_public\_key) | MongoDB Atlas programmatic API public key | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The AWS Region in which to deploy the resources | `string` | n/a | yes |
-| <a name="input_worker_node_ssh_key_name"></a> [worker\_node\_ssh\_key\_name](#input\_worker\_node\_ssh\_key\_name) | Name of the SSH Key Pair used for the worker nodes | `string` | n/a | yes |
+| <a name="input_worker_node_ssh_key_name"></a> [worker\_node\_ssh\_key\_name](#input\_worker\_node\_ssh\_key\_name) | Name of the SSH Key Pair used for the worker nodes | `string` | `null` | no |
 
 ## Outputs
 

--- a/infra-examples/aws/main.tf
+++ b/infra-examples/aws/main.tf
@@ -29,18 +29,18 @@ module "main_vpc" {
   ]
 
   public_subnet_tags = {
-    "Tier"                                        = "Public"
-    "kubernetes.io/role/elb"                      = "1"
+    "Tier"                   = "Public"
+    "kubernetes.io/role/elb" = "1"
   }
 
   private_subnet_tags = {
-    "Tier"                                        = "Private"
-    "kubernetes.io/role/internal-elb"             = "1"
+    "Tier"                            = "Private"
+    "kubernetes.io/role/internal-elb" = "1"
   }
 }
 
 module "kubernetes_cluster" {
-  source     = "../../terraform/modules/aws/eks"
+  source = "../../terraform/modules/aws/eks"
 
   environment = var.environment
   vpc_id      = module.main_vpc.vpc_id

--- a/infra-examples/aws/main.tf
+++ b/infra-examples/aws/main.tf
@@ -1,5 +1,5 @@
 locals {
-  kubernetes_version = "1.30"
+  kubernetes_version = "1.36"
   cluster_name       = "${var.kubernetes_cluster_name}-${var.environment}"
 }
 
@@ -11,7 +11,7 @@ module "main_vpc" {
   source = "../../terraform/modules/aws/vpc"
 
   environment        = var.environment
-  availability_zones = data.aws_availability_zones.available.names
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 3)
 
   single_nat_gateway     = true
   one_nat_gateway_per_az = false
@@ -44,9 +44,11 @@ module "kubernetes_cluster" {
 
   environment = var.environment
   vpc_id      = module.main_vpc.vpc_id
+  subnet_ids  = module.main_vpc.private_subnets
 
   cluster_name         = var.kubernetes_cluster_name
   kubernetes_version   = local.kubernetes_version
+  ubuntu_version       = "resolute-26.04"
   registry_credentials = var.docker_registry_credentials
 
   worker_node_ssh_key_name   = var.worker_node_ssh_key_name
@@ -66,6 +68,7 @@ module "mysql_database" {
 
   environment = var.environment
   vpc_id      = module.main_vpc.vpc_id
+  subnet_ids  = module.main_vpc.private_subnets
 
   database_cluster_name = "${module.kubernetes_cluster.cluster_name}-mysql"
 }
@@ -81,6 +84,7 @@ module "mongodb_database" {
   aws_account_id          = data.aws_caller_identity.current.account_id
   mongodbatlas_project_id = var.mongodbatlas_project_id
   mongodbatlas_cidr_block = var.mongodbatlas_cidr_block
+  private_route_table_ids = module.main_vpc.private_route_table_ids
 
   database_cluster_name = "${module.kubernetes_cluster.cluster_name}-mongodb"
 }

--- a/infra-examples/aws/providers.tf
+++ b/infra-examples/aws/providers.tf
@@ -21,4 +21,7 @@ provider "aws" {
   region = var.region
 }
 
-provider "mongodbatlas" {}
+provider "mongodbatlas" {
+  public_key  = var.mongodbatlas_public_key
+  private_key = var.mongodbatlas_private_key
+}

--- a/infra-examples/aws/providers.tf
+++ b/infra-examples/aws/providers.tf
@@ -1,8 +1,18 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      version = ">=5.88"
+      source  = "hashicorp/aws"
+      version = "~> 6.62"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.9"
+    }
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = "~> 2.17"
     }
   }
 }
@@ -10,3 +20,5 @@ terraform {
 provider "aws" {
   region = var.region
 }
+
+provider "mongodbatlas" {}

--- a/infra-examples/aws/variables.tf
+++ b/infra-examples/aws/variables.tf
@@ -22,6 +22,7 @@ variable "kubernetes_cluster_name" {
 variable "worker_node_ssh_key_name" {
   type        = string
   description = "Name of the SSH Key Pair used for the worker nodes"
+  default     = null
 }
 
 variable "mongodbatlas_project_id" {
@@ -32,4 +33,16 @@ variable "mongodbatlas_project_id" {
 variable "mongodbatlas_cidr_block" {
   type        = string
   description = "The CIDR block in MongoDB Atlas"
+}
+
+variable "mongodbatlas_public_key" {
+  type        = string
+  description = "MongoDB Atlas programmatic API public key"
+  sensitive   = true
+}
+
+variable "mongodbatlas_private_key" {
+  type        = string
+  description = "MongoDB Atlas programmatic API private key"
+  sensitive   = true
 }

--- a/infra-examples/digitalocean/README.md
+++ b/infra-examples/digitalocean/README.md
@@ -4,6 +4,10 @@ This is an example implementation to create a production grade infrastructure fo
 
 ## Important notes
 
+Spaces credentials are required by the DigitalOcean provider. Pass them with
+`TF_VAR_spaces_access_id` / `TF_VAR_spaces_secret_key` or a gitignored
+`secrets.auto.tfvars` file. Do not commit access keys.
+
 Be aware that the current implementation does not support the creation of MongoDB users and Spaces buckets through Tutor plugins.
 
 While Tutor can handle MySQL database and user creation, Terraform is required (as of now) for setting up MongoDB databases and users. This approach is not ideal as it necessitates running Terraform code when adding or removing instances, which contradicts the goal of separating cluster provisioning from instance provisioning. Until a more streamlined solution, such as a plugin or automation tool, is developed, users must manually manage these resources. For now, please ensure you manually configure MongoDB users and Spaces buckets to maintain a fully functional environment (either using Terraform or other methods).
@@ -11,22 +15,22 @@ While Tutor can handle MySQL database and user creation, Terraform is required (
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | >=2.45 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.16 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >=1.17 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >=2.34 |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | ~> 2.100 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.3 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | 2.45.0 |
+| ---- | ------- |
+| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | 2.100.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_kubernetes_cluster"></a> [kubernetes\_cluster](#module\_kubernetes\_cluster) | ../../terraform/modules/digitalocean/doks | n/a |
 | <a name="module_main_vpc"></a> [main\_vpc](#module\_main\_vpc) | ../../terraform/modules/digitalocean/vpc | n/a |
 | <a name="module_mongodb_database"></a> [mongodb\_database](#module\_mongodb\_database) | ../../terraform/modules/digitalocean/database | n/a |
@@ -36,20 +40,20 @@ While Tutor can handle MySQL database and user creation, Terraform is required (
 ## Resources
 
 | Name | Type |
-|------|------|
-| [digitalocean_database_db.forum_database](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/database_db) | resource |
+| ---- | ---- |
 | [digitalocean_project.project](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/project) | resource |
-| [digitalocean_kubernetes_cluster.cluster](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/kubernetes_cluster) | data source |
 | [digitalocean_kubernetes_versions.available_versions](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/kubernetes_versions) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_do_access_token"></a> [do\_access\_token](#input\_do\_access\_token) | DitialOcean access token. | `string` | n/a | yes |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_do_access_token"></a> [do\_access\_token](#input\_do\_access\_token) | DigitalOcean access token. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The DigitalOcean project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
 | <a name="input_kubernetes_cluster_name"></a> [kubernetes\_cluster\_name](#input\_kubernetes\_cluster\_name) | Name of the DigitalOcean Kubernetes cluster to create. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | DigitalOcean region to create the resources in. | `string` | n/a | yes |
+| <a name="input_spaces_access_id"></a> [spaces\_access\_id](#input\_spaces\_access\_id) | DigitalOcean Spaces access key ID. Provide via TF\_VAR\_spaces\_access\_id or a gitignored secrets.auto.tfvars file. | `string` | n/a | yes |
+| <a name="input_spaces_secret_key"></a> [spaces\_secret\_key](#input\_spaces\_secret\_key) | DigitalOcean Spaces secret key. Provide via TF\_VAR\_spaces\_secret\_key or a gitignored secrets.auto.tfvars file. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/infra-examples/digitalocean/main.tf
+++ b/infra-examples/digitalocean/main.tf
@@ -3,25 +3,25 @@ data "digitalocean_kubernetes_versions" "available_versions" {}
 module "main_vpc" {
   source = "../../terraform/modules/digitalocean/vpc"
 
-  region = var.region
+  region      = var.region
   environment = var.environment
 }
 
 module "kubernetes_cluster" {
   source = "../../terraform/modules/digitalocean/doks"
 
-  region = var.region
+  region      = var.region
   environment = var.environment
-  vpc_id = module.main_vpc.vpc_id
+  vpc_id      = module.main_vpc.vpc_id
 
-  cluster_name = var.kubernetes_cluster_name
+  cluster_name       = var.kubernetes_cluster_name
   kubernetes_version = data.digitalocean_kubernetes_versions.available_versions.latest_version
 }
 
 module "spaces" {
   source = "../../terraform/modules/digitalocean/spaces"
 
-  region = var.region
+  region      = var.region
   environment = var.environment
 
   bucket_prefix = "my-institute"
@@ -30,18 +30,18 @@ module "spaces" {
 module "mysql_database" {
   source = "../../terraform/modules/digitalocean/database"
 
-  region = var.region
-  environment = var.environment
-  access_token = var.do_access_token
-  vpc_id = module.main_vpc.vpc_id
+  region                  = var.region
+  environment             = var.environment
+  access_token            = var.do_access_token
+  vpc_id                  = module.main_vpc.vpc_id
   kubernetes_cluster_name = var.kubernetes_cluster_name
 
-  database_engine = "mysql"
-  database_engine_version = 8
-  database_cluster_instances = 1
-  database_cluster_instance_size = "db-s-1vcpu-1gb"
-  database_maintenance_window_day = "sunday"
-  database_maintenance_window_time = "01:00:00"
+  database_engine                  = "mysql"
+  database_engine_version          = "8"
+  database_cluster_instances       = 1
+  database_cluster_instance_size   = "db-s-1vcpu-1gb"
+  database_maintenance_window_day  = "sunday"
+  database_maintenance_window_time = "01:00"
 
   # Database cluster firewalls cannot use VPC CIDR, therefore the access is
   # limited to the k8s cluster
@@ -56,18 +56,18 @@ module "mysql_database" {
 module "mongodb_database" {
   source = "../../terraform/modules/digitalocean/database"
 
-  region = var.region
-  environment = var.environment
-  access_token = var.do_access_token
-  vpc_id = module.main_vpc.vpc_id
+  region                  = var.region
+  environment             = var.environment
+  access_token            = var.do_access_token
+  vpc_id                  = module.main_vpc.vpc_id
   kubernetes_cluster_name = var.kubernetes_cluster_name
 
-  database_engine = "mongodb"
-  database_engine_version = 7
-  database_cluster_instances = 3
-  database_cluster_instance_size = "db-s-1vcpu-1gb"
-  database_maintenance_window_day = "sunday"
-  database_maintenance_window_time = "1:00"
+  database_engine                  = "mongodb"
+  database_engine_version          = "7"
+  database_cluster_instances       = 3
+  database_cluster_instance_size   = "db-s-1vcpu-1gb"
+  database_maintenance_window_day  = "sunday"
+  database_maintenance_window_time = "01:00"
 
   # Database cluster firewalls cannot use VPC CIDR, therefore the access is
   # limited to the k8s cluster

--- a/infra-examples/digitalocean/providers.tf
+++ b/infra-examples/digitalocean/providers.tf
@@ -1,56 +1,24 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = ">=2.45"
+      version = "~> 2.100"
     }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
-      version = ">=2.34"
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.9"
     }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">=1.17"
-    }
-    helm = {
-      source = "hashicorp/helm"
-      version = ">=2.16"
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.3"
     }
   }
-}
-
-# Pre-declare data sources that we can use to get the cluster ID and auth info,
-# once it's created. Set the `depends_on` so that the data source doesn't try
-# to read from a cluster that doesn't exist, causing failures when trying to
-# run a `terraform plan`.
-data "digitalocean_kubernetes_cluster" "cluster" {
-  name = module.kubernetes_cluster.cluster_name
-  depends_on = [module.kubernetes_cluster.cluster_id]
 }
 
 provider "digitalocean" {
-  token = var.do_access_token
-  spaces_access_id = "DO00M682HAUD3KXUQNL3"
-  spaces_secret_key = "fnoviZN11Y0NAoeAXxUrOU0liJyKcfP4yQboHJkJKY0"
-}
-
-provider "kubernetes" {
-  host                   = data.digitalocean_kubernetes_cluster.cluster.endpoint
-  token                  = data.digitalocean_kubernetes_cluster.cluster.kube_config[0].token
-  cluster_ca_certificate = base64decode(data.digitalocean_kubernetes_cluster.cluster.kube_config[0].cluster_ca_certificate)
-}
-
-provider "helm" {
-  kubernetes {
-    host                   = data.digitalocean_kubernetes_cluster.cluster.endpoint
-    token                  = data.digitalocean_kubernetes_cluster.cluster.kube_config[0].token
-    cluster_ca_certificate = base64decode(data.digitalocean_kubernetes_cluster.cluster.kube_config[0].cluster_ca_certificate)
-  }
-}
-
-provider "kubectl" {
-  host                   = data.digitalocean_kubernetes_cluster.cluster.endpoint
-  token                  = data.digitalocean_kubernetes_cluster.cluster.kube_config[0].token
-  cluster_ca_certificate = base64decode(data.digitalocean_kubernetes_cluster.cluster.kube_config[0].cluster_ca_certificate)
-  load_config_file       = false
+  token             = var.do_access_token
+  spaces_access_id  = var.spaces_access_id
+  spaces_secret_key = var.spaces_secret_key
 }

--- a/infra-examples/digitalocean/variables.tf
+++ b/infra-examples/digitalocean/variables.tf
@@ -1,12 +1,24 @@
 variable "do_access_token" {
-  type = string
-  description = "DitialOcean access token."
-  sensitive = true
+  type        = string
+  description = "DigitalOcean access token."
+  sensitive   = true
+}
+
+variable "spaces_access_id" {
+  type        = string
+  description = "DigitalOcean Spaces access key ID. Provide via TF_VAR_spaces_access_id or a gitignored secrets.auto.tfvars file."
+  sensitive   = true
+}
+
+variable "spaces_secret_key" {
+  type        = string
+  description = "DigitalOcean Spaces secret key. Provide via TF_VAR_spaces_secret_key or a gitignored secrets.auto.tfvars file."
+  sensitive   = true
 }
 
 variable "kubernetes_cluster_name" {
-    type = string
-    description = "Name of the DigitalOcean Kubernetes cluster to create."
+  type        = string
+  description = "Name of the DigitalOcean Kubernetes cluster to create."
 }
 
 variable "region" {

--- a/terraform/modules/aws/eks/README.md
+++ b/terraform/modules/aws/eks/README.md
@@ -24,7 +24,6 @@
 | Name | Type |
 | ---- | ---- |
 | [aws_ami.latest_ubuntu_eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
-| [aws_subnets.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
@@ -37,6 +36,7 @@
 | <a name="input_cluster_security_group_name"></a> [cluster\_security\_group\_name](#input\_cluster\_security\_group\_name) | Cluster security group name | `string` | `null` | no |
 | <a name="input_cluster_security_group_use_name_prefix"></a> [cluster\_security\_group\_use\_name\_prefix](#input\_cluster\_security\_group\_use\_name\_prefix) | Determinate if it is necessary to create an security group prefix for the cluster | `bool` | `true` | no |
 | <a name="input_cluster_tags"></a> [cluster\_tags](#input\_cluster\_tags) | A map of tags to add to the cluster | `map(string)` | `{}` | no |
+| <a name="input_control_plane_subnet_ids"></a> [control\_plane\_subnet\_ids](#input\_control\_plane\_subnet\_ids) | Subnet IDs for the EKS control plane. Defaults to subnet\_ids. Set this when an existing cluster cannot add availability zones. | `list(string)` | `null` | no |
 | <a name="input_enable_cluster_autoscaler"></a> [enable\_cluster\_autoscaler](#input\_enable\_cluster\_autoscaler) | Determines whether to prepare the cluster to use cluster autoscaler | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The AWS project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Cluster IAM role name | `string` | `null` | no |
@@ -45,10 +45,10 @@
 | <a name="input_max_worker_node_count"></a> [max\_worker\_node\_count](#input\_max\_worker\_node\_count) | Maximum node count in the autoscaling group | `number` | `3` | no |
 | <a name="input_min_worker_node_count"></a> [min\_worker\_node\_count](#input\_min\_worker\_node\_count) | Minimum node count in the autoscaling group | `number` | `1` | no |
 | <a name="input_post_bootstrap_user_data"></a> [post\_bootstrap\_user\_data](#input\_post\_bootstrap\_user\_data) | Allow to add post bootstrap user data | `string` | `null` | no |
-| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | List of private subnets | `list(string)` | <pre>[<br/>  "10.10.0.0/21",<br/>  "10.10.8.0/21"<br/>]</pre> | no |
 | <a name="input_registry_credentials"></a> [registry\_credentials](#input\_registry\_credentials) | Image registry credentials to be added to the node | `string` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Private subnet IDs for the cluster and node groups. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Ubuntu version to use (e.g. focal-20.04) when no ami\_id is provided | `string` | `"jammy-22.04"` | no |
+| <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Ubuntu version to use when no ami\_id is provided (e.g. jammy-22.04 for EKS 1.29-1.32, noble-24.04 for 1.31-1.35, resolute-26.04 for 1.35+) | `string` | `"jammy-22.04"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC to use for the Kubernetes cluster. | `string` | n/a | yes |
 | <a name="input_worker_node_capacity_type"></a> [worker\_node\_capacity\_type](#input\_worker\_node\_capacity\_type) | Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT` | `string` | `"ON_DEMAND"` | no |
 | <a name="input_worker_node_count"></a> [worker\_node\_count](#input\_worker\_node\_count) | Desired autoscaling node count | `number` | `2` | no |
@@ -57,7 +57,7 @@
 | <a name="input_worker_node_group_name"></a> [worker\_node\_group\_name](#input\_worker\_node\_group\_name) | Name of the node group | `string` | `"ubuntu_worker"` | no |
 | <a name="input_worker_node_groups_tags"></a> [worker\_node\_groups\_tags](#input\_worker\_node\_groups\_tags) | A map of tags to add to all node group resources | `map(string)` | `{}` | no |
 | <a name="input_worker_node_instance_types"></a> [worker\_node\_instance\_types](#input\_worker\_node\_instance\_types) | EC2 Instance type for the nodes | `list(string)` | n/a | yes |
-| <a name="input_worker_node_ssh_key_name"></a> [worker\_node\_ssh\_key\_name](#input\_worker\_node\_ssh\_key\_name) | Name of the SSH Key Pair used for the worker nodes | `string` | n/a | yes |
+| <a name="input_worker_node_ssh_key_name"></a> [worker\_node\_ssh\_key\_name](#input\_worker\_node\_ssh\_key\_name) | Name of an existing EC2 key pair used to SSH to the worker nodes | `string` | `null` | no |
 
 ## Outputs
 

--- a/terraform/modules/aws/eks/README.md
+++ b/terraform/modules/aws/eks/README.md
@@ -1,25 +1,28 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.62 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.62 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
-| <a name="module_cluster_autoscaler_irsa_role"></a> [cluster\_autoscaler\_irsa\_role](#module\_cluster\_autoscaler\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.47 |
-| <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.47 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 20.31 |
+| ---- | ------ | ------- |
+| <a name="module_cluster_autoscaler_irsa_role"></a> [cluster\_autoscaler\_irsa\_role](#module\_cluster\_autoscaler\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.8 |
+| <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.8 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 21.25 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_ami.latest_ubuntu_eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_subnets.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -27,7 +30,7 @@ No requirements.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | EKS nodes AMI ID | `string` | `""` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the Kubernetes cluster. | `string` | n/a | yes |
 | <a name="input_cluster_security_group_description"></a> [cluster\_security\_group\_description](#input\_cluster\_security\_group\_description) | Cluster security group description | `string` | `"EKS cluster security group"` | no |
@@ -59,7 +62,7 @@ No requirements.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | Endpoint for your Kubernetes API server |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the EKS cluster |
 | <a name="output_cluster_version"></a> [cluster\_version](#output\_cluster\_version) | The Kubernetes version for the cluster |

--- a/terraform/modules/aws/eks/main.tf
+++ b/terraform/modules/aws/eks/main.tf
@@ -21,6 +21,8 @@ locals {
       registry_credentials = var.registry_credentials
     }
   )
+
+  control_plane_subnet_ids = var.control_plane_subnet_ids != null ? var.control_plane_subnet_ids : var.subnet_ids
 }
 
 data "aws_ami" "latest_ubuntu_eks" {
@@ -32,7 +34,7 @@ data "aws_ami" "latest_ubuntu_eks" {
 
   filter {
     name   = "name"
-    values = ["ubuntu-eks/k8s_${var.kubernetes_version}/images/hvm-ssd/ubuntu-${var.ubuntu_version}-amd64-server-*"]
+    values = ["ubuntu-eks/k8s_${var.kubernetes_version}/images/hvm-ssd*/ubuntu-${var.ubuntu_version}-amd64-server-*"]
   }
 }
 
@@ -40,29 +42,21 @@ data "aws_vpc" "main" {
   id = var.vpc_id
 }
 
-data "aws_subnets" "main" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.main.id]
-  }
-
-  tags = {
-    Tier = "Private"
-  }
-}
-
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.25"
 
-  name                   = var.cluster_name
-  kubernetes_version     = var.kubernetes_version
-  endpoint_public_access = true
-  vpc_id                 = data.aws_vpc.main.id
-  subnet_ids             = data.aws_subnets.main.ids
-  enable_irsa            = true
-  cluster_tags           = var.cluster_tags
-  tags                   = var.tags
+  name               = var.cluster_name
+  kubernetes_version = var.kubernetes_version
+  vpc_id             = data.aws_vpc.main.id
+  subnet_ids         = var.subnet_ids
+
+  control_plane_subnet_ids                 = local.control_plane_subnet_ids
+  endpoint_public_access                   = true
+  enable_irsa                              = true
+  enable_cluster_creator_admin_permissions = true
+  cluster_tags                             = var.cluster_tags
+  tags                                     = var.tags
 
   create_cloudwatch_log_group = false
   enabled_log_types           = []
@@ -72,10 +66,12 @@ module "eks" {
       name = "coredns"
     }
     kube-proxy = {
-      name = "kube-proxy"
+      name           = "kube-proxy"
+      before_compute = true
     }
     vpc-cni = {
-      name = "vpc-cni"
+      name           = "vpc-cni"
+      before_compute = true
     }
     aws-ebs-csi-driver = {
       name                     = "aws-ebs-csi-driver"
@@ -111,9 +107,9 @@ module "eks" {
     ubuntu_worker = {
       ami_id                         = var.ami_id != "" ? var.ami_id : data.aws_ami.latest_ubuntu_eks[0].id
       ami_type                       = "AL2_x86_64"
-      key_name                       = var.worker_node_ssh_key_name
+      key_name                       = var.worker_node_ssh_key_name == "" ? null : var.worker_node_ssh_key_name
       name                           = var.worker_node_group_name
-      subnet_ids                     = data.aws_subnets.main.ids
+      subnet_ids                     = var.subnet_ids
       use_latest_ami_release_version = false
 
       # This will ensure the bootstrap user data is used to join the node

--- a/terraform/modules/aws/eks/main.tf
+++ b/terraform/modules/aws/eks/main.tf
@@ -1,7 +1,10 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 6.62"
     }
   }
 }
@@ -18,16 +21,12 @@ locals {
       registry_credentials = var.registry_credentials
     }
   )
-
-  # Define the default IAM role additional policies for all the node groups
-  # every element must define:
-  #   - A key for the policy. It can be any string
-  #   - A value which is the ARN of the policy to add
-  #   - An enable key which determines if the policy is added or not
-  node_group_defaults_iam_role_additional_policies = []
 }
 
 data "aws_ami" "latest_ubuntu_eks" {
+  # If a custom AMI is provided, do not fetch the latest Ubuntu EKS AMI
+  count = var.ami_id == "" ? 1 : 0
+
   most_recent = true
   owners      = ["099720109477"] # Canonical
 
@@ -53,21 +52,22 @@ data "aws_subnets" "main" {
 }
 
 module "eks" {
-  source                         = "terraform-aws-modules/eks/aws"
-  version                        = "~> 20.31"
-  cluster_name                   = var.cluster_name
-  cluster_version                = var.kubernetes_version
-  cluster_endpoint_public_access = true
-  vpc_id                         = data.aws_vpc.main.id
-  subnet_ids                     = data.aws_subnets.main.ids
-  enable_irsa                    = true
-  cluster_tags                   = var.cluster_tags
-  tags                           = var.tags
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.25"
+
+  name                   = var.cluster_name
+  kubernetes_version     = var.kubernetes_version
+  endpoint_public_access = true
+  vpc_id                 = data.aws_vpc.main.id
+  subnet_ids             = data.aws_subnets.main.ids
+  enable_irsa            = true
+  cluster_tags           = var.cluster_tags
+  tags                   = var.tags
 
   create_cloudwatch_log_group = false
-  cluster_enabled_log_types   = []
+  enabled_log_types           = []
 
-  cluster_addons = {
+  addons = {
     coredns = {
       name = "coredns"
     }
@@ -79,12 +79,12 @@ module "eks" {
     }
     aws-ebs-csi-driver = {
       name                     = "aws-ebs-csi-driver"
-      service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
+      service_account_role_arn = module.ebs_csi_irsa_role.arn
     }
   }
 
   # The security group rules below should not conflict with the recommended rules defined
-  # here: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v19.21.0/node_groups.tf#L128
+  # here: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v21.25.0/node_groups.tf
   node_security_group_additional_rules = {
     ssh_access = {
       description = "Grant access ssh access to the nodes"
@@ -96,30 +96,27 @@ module "eks" {
     }
   }
 
-  # Disable secrets encryption
-  cluster_encryption_config = {}
+  # Keep the previous "no custom KMS key" behavior; in v21 setting `{}` enables a module-managed key.
+  encryption_config = null
 
   iam_role_use_name_prefix = var.iam_role_use_name_prefix
   iam_role_name            = var.iam_role_name
 
   # for security group
-  cluster_security_group_description     = var.cluster_security_group_description
-  cluster_security_group_use_name_prefix = var.cluster_security_group_use_name_prefix
-  cluster_security_group_name            = var.cluster_security_group_name
-
-  eks_managed_node_group_defaults = {
-    iam_role_additional_policies = { for s in local.node_group_defaults_iam_role_additional_policies : s.key => s.value if s.enable }
-  }
+  security_group_description     = var.cluster_security_group_description
+  security_group_use_name_prefix = var.cluster_security_group_use_name_prefix
+  security_group_name            = var.cluster_security_group_name
 
   eks_managed_node_groups = {
     ubuntu_worker = {
+      ami_id                         = var.ami_id != "" ? var.ami_id : data.aws_ami.latest_ubuntu_eks[0].id
+      ami_type                       = "AL2_x86_64"
+      key_name                       = var.worker_node_ssh_key_name
+      name                           = var.worker_node_group_name
+      subnet_ids                     = data.aws_subnets.main.ids
+      use_latest_ami_release_version = false
 
-      ami_id     = var.ami_id != "" ? var.ami_id : data.aws_ami.latest_ubuntu_eks.id
-      key_name   = var.worker_node_ssh_key_name
-      name       = var.worker_node_group_name
-      subnet_ids = data.aws_subnets.main.ids
-
-      # This will ensure the boostrap user data is used to join the node
+      # This will ensure the bootstrap user data is used to join the node
       # By default, EKS managed node groups will not append bootstrap script;
       # this adds it back in using the default template provided by the module
       # Note: this assumes the AMI provided is an EKS optimized AMI derivative
@@ -150,10 +147,11 @@ module "eks" {
 }
 
 module "ebs_csi_irsa_role" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.47"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.8"
 
-  role_name             = "ebs-csi-controller-${var.cluster_name}"
+  name                  = "ebs-csi-controller-${var.cluster_name}"
+  use_name_prefix       = false
   attach_ebs_csi_policy = true
   tags                  = var.tags
 
@@ -167,14 +165,15 @@ module "ebs_csi_irsa_role" {
 
 # Role required by cluster_autoscaler
 module "cluster_autoscaler_irsa_role" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.47"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.8"
 
   count = var.enable_cluster_autoscaler ? 1 : 0
 
-  role_name                        = "cluster-autoscaler-${module.eks.cluster_name}"
+  name                             = "cluster-autoscaler-${module.eks.cluster_name}"
+  use_name_prefix                  = false
   attach_cluster_autoscaler_policy = true
-  cluster_autoscaler_cluster_ids   = [module.eks.cluster_name]
+  cluster_autoscaler_cluster_names = [module.eks.cluster_name]
   tags                             = var.tags
 
   oidc_providers = {

--- a/terraform/modules/aws/eks/variables.tf
+++ b/terraform/modules/aws/eks/variables.tf
@@ -48,10 +48,15 @@ variable "vpc_id" {
   description = "ID of the VPC to use for the Kubernetes cluster."
 }
 
-variable "private_subnets" {
+variable "subnet_ids" {
   type        = list(string)
-  default     = ["10.10.0.0/21", "10.10.8.0/21"]
-  description = "List of private subnets"
+  description = "Private subnet IDs for the cluster and node groups."
+}
+
+variable "control_plane_subnet_ids" {
+  type        = list(string)
+  default     = null
+  description = "Subnet IDs for the EKS control plane. Defaults to subnet_ids. Set this when an existing cluster cannot add availability zones."
 }
 
 variable "worker_node_instance_types" {
@@ -85,7 +90,8 @@ variable "min_worker_node_count" {
 
 variable "worker_node_ssh_key_name" {
   type        = string
-  description = "Name of the SSH Key Pair used for the worker nodes"
+  description = "Name of an existing EC2 key pair used to SSH to the worker nodes"
+  default     = null
 }
 
 variable "worker_node_extra_ssh_cidrs" {
@@ -124,7 +130,7 @@ variable "enable_cluster_autoscaler" {
 }
 
 variable "ubuntu_version" {
-  description = "Ubuntu version to use (e.g. focal-20.04) when no ami_id is provided"
+  description = "Ubuntu version to use when no ami_id is provided (e.g. jammy-22.04 for EKS 1.29-1.32, noble-24.04 for 1.31-1.35, resolute-26.04 for 1.35+)"
   type        = string
   default     = "jammy-22.04"
   validation { # Validates wheter the value is in format str-num.num

--- a/terraform/modules/aws/mongodb/README.md
+++ b/terraform/modules/aws/mongodb/README.md
@@ -25,8 +25,8 @@ No modules.
 | ---- | ---- |
 | [aws_route.peeraccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_vpc_peering_connection_accepter.accept_mongo_peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) | resource |
+| [mongodbatlas_advanced_cluster.cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) | resource |
 | [mongodbatlas_cloud_backup_schedule.backup_schedule](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_backup_schedule) | resource |
-| [mongodbatlas_cluster.cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster) | resource |
 | [mongodbatlas_database_user.users](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/database_user) | resource |
 | [mongodbatlas_network_container.cluster_network_container](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/network_container) | resource |
 | [mongodbatlas_network_peering.cluster_network_peering](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/network_peering) | resource |
@@ -57,9 +57,10 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The AWS project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
 | <a name="input_is_database_autoscaling_compute_enabled"></a> [is\_database\_autoscaling\_compute\_enabled](#input\_is\_database\_autoscaling\_compute\_enabled) | Whether to enable autoscaling of database instances | `bool` | `false` | no |
 | <a name="input_is_database_autoscaling_disk_gb_enabled"></a> [is\_database\_autoscaling\_disk\_gb\_enabled](#input\_is\_database\_autoscaling\_disk\_gb\_enabled) | Whether to enable autoscaling disk size for the database instance | `bool` | `true` | no |
-| <a name="input_is_database_storage_encrypted"></a> [is\_database\_storage\_encrypted](#input\_is\_database\_storage\_encrypted) | Whether the database storage is encrypted in rest | `bool` | `true` | no |
+| <a name="input_is_database_storage_encrypted"></a> [is\_database\_storage\_encrypted](#input\_is\_database\_storage\_encrypted) | Enable Atlas Encryption at Rest with customer-managed AWS KMS keys | `bool` | `false` | no |
 | <a name="input_mongodbatlas_cidr_block"></a> [mongodbatlas\_cidr\_block](#input\_mongodbatlas\_cidr\_block) | The CIDR block in MongoDB Atlas | `string` | n/a | yes |
 | <a name="input_mongodbatlas_project_id"></a> [mongodbatlas\_project\_id](#input\_mongodbatlas\_project\_id) | The ID of the MongoDB Atlas project | `string` | n/a | yes |
+| <a name="input_private_route_table_ids"></a> [private\_route\_table\_ids](#input\_private\_route\_table\_ids) | Private route table IDs that should route to the Atlas peering connection | `list(string)` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The AWS Region in which to deploy the resources | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC to use for the MongoDB cluster | `string` | n/a | yes |
 

--- a/terraform/modules/aws/mongodb/README.md
+++ b/terraform/modules/aws/mongodb/README.md
@@ -1,14 +1,19 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.62 |
+| <a name="requirement_mongodbatlas"></a> [mongodbatlas](#requirement\_mongodbatlas) | ~> 2.17 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_mongodbatlas"></a> [mongodbatlas](#provider\_mongodbatlas) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.62 |
+| <a name="provider_mongodbatlas"></a> [mongodbatlas](#provider\_mongodbatlas) | ~> 2.17 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.9 |
 
 ## Modules
 
@@ -17,7 +22,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_route.peeraccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_vpc_peering_connection_accepter.accept_mongo_peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) | resource |
 | [mongodbatlas_cloud_backup_schedule.backup_schedule](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_backup_schedule) | resource |
@@ -32,7 +37,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account ID | `string` | n/a | yes |
 | <a name="input_database_analytics_nodes"></a> [database\_analytics\_nodes](#input\_database\_analytics\_nodes) | The number of analytics nodes in the MongoDB cluster | `number` | `null` | no |
 | <a name="input_database_autoscaling_max_instances"></a> [database\_autoscaling\_max\_instances](#input\_database\_autoscaling\_max\_instances) | The maximum number of instances to have in the database instance autoscaling group | `number` | `3` | no |
@@ -48,7 +53,7 @@ No modules.
 | <a name="input_database_storage_ipos"></a> [database\_storage\_ipos](#input\_database\_storage\_ipos) | The disk IOPS to have for the database instance | `number` | `null` | no |
 | <a name="input_database_storage_size"></a> [database\_storage\_size](#input\_database\_storage\_size) | The storage assigned to the database instance | `number` | `null` | no |
 | <a name="input_database_storage_type"></a> [database\_storage\_type](#input\_database\_storage\_type) | The storage type to use for the database instance | `string` | `null` | no |
-| <a name="input_database_users"></a> [database\_users](#input\_database\_users) | Map of additional user and database names. | <pre>map(object({<br/>    username       = string<br/>    database       = string<br/>  }))</pre> | `{}` | no |
+| <a name="input_database_users"></a> [database\_users](#input\_database\_users) | Map of additional user and database names. | <pre>map(object({<br/>    username = string<br/>    database = string<br/>  }))</pre> | `{}` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The AWS project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
 | <a name="input_is_database_autoscaling_compute_enabled"></a> [is\_database\_autoscaling\_compute\_enabled](#input\_is\_database\_autoscaling\_compute\_enabled) | Whether to enable autoscaling of database instances | `bool` | `false` | no |
 | <a name="input_is_database_autoscaling_disk_gb_enabled"></a> [is\_database\_autoscaling\_disk\_gb\_enabled](#input\_is\_database\_autoscaling\_disk\_gb\_enabled) | Whether to enable autoscaling disk size for the database instance | `bool` | `true` | no |
@@ -61,7 +66,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cluster_address"></a> [cluster\_address](#output\_cluster\_address) | The address of the database cluster |
 | <a name="output_cluster_connection_strings"></a> [cluster\_connection\_strings](#output\_cluster\_connection\_strings) | Connection strings for the database cluster |
 | <a name="output_database_cluster_cluster_id"></a> [database\_cluster\_cluster\_id](#output\_database\_cluster\_cluster\_id) | The cluster ID of the database cluster |

--- a/terraform/modules/aws/mongodb/main.tf
+++ b/terraform/modules/aws/mongodb/main.tf
@@ -1,13 +1,18 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 6.62"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.9"
     }
     mongodbatlas = {
-      source = "mongodb/mongodbatlas"
+      source  = "mongodb/mongodbatlas"
+      version = "~> 2.17"
     }
   }
 }

--- a/terraform/modules/aws/mongodb/main.tf
+++ b/terraform/modules/aws/mongodb/main.tf
@@ -25,47 +25,67 @@ data "aws_vpc" "main" {
   id = var.vpc_id
 }
 
-resource "mongodbatlas_cluster" "cluster" {
+resource "mongodbatlas_advanced_cluster" "cluster" {
   depends_on = [mongodbatlas_network_container.cluster_network_container]
 
-  project_id             = var.mongodbatlas_project_id
-  name                   = "${var.database_cluster_name}-${var.environment}"
-  mongo_db_major_version = var.database_cluster_version
-
-  cluster_type = var.database_cluster_type
-  replication_specs {
-    num_shards = var.database_shards
-
-    regions_config {
-      priority        = 7
-      region_name     = local.region
-      electable_nodes = var.database_electable_nodes
-      read_only_nodes = var.database_read_only_nodes
-      analytics_nodes = var.database_analytics_nodes
-    }
-  }
-
-  # Auto-Scaling Settings
-  auto_scaling_disk_gb_enabled                    = var.is_database_autoscaling_disk_gb_enabled
-  auto_scaling_compute_enabled                    = var.is_database_autoscaling_compute_enabled
-  auto_scaling_compute_scale_down_enabled         = var.is_database_autoscaling_compute_enabled
-  provider_auto_scaling_compute_min_instance_size = var.database_autoscaling_min_instances
-  provider_auto_scaling_compute_max_instance_size = var.database_autoscaling_max_instances
-
-  # Provider Settings
-  provider_name               = "AWS"
-  provider_region_name        = local.region
-  disk_size_gb                = var.database_storage_size
-  provider_disk_iops          = var.database_storage_ipos
-  provider_volume_type        = var.database_storage_type
-  cloud_backup                = true
-  provider_instance_size_name = var.database_cluster_instance_size
+  project_id                  = var.mongodbatlas_project_id
+  name                        = "${var.database_cluster_name}-${var.environment}"
+  mongo_db_major_version      = var.database_cluster_version
+  cluster_type                = var.database_cluster_type
+  backup_enabled              = true
+  use_effective_fields        = var.is_database_autoscaling_compute_enabled ? true : null
   encryption_at_rest_provider = var.is_database_storage_encrypted ? "AWS" : "NONE"
+
+  replication_specs = [
+    for _ in range(var.database_shards) : {
+      region_configs = [{
+        priority      = 7
+        provider_name = "AWS"
+        region_name   = local.region
+
+        electable_specs = {
+          instance_size   = var.database_cluster_instance_size
+          node_count      = var.database_electable_nodes
+          disk_iops       = var.database_storage_ipos
+          ebs_volume_type = var.database_storage_type
+          disk_size_gb    = var.is_database_autoscaling_disk_gb_enabled ? null : var.database_storage_size
+        }
+
+        analytics_specs = var.database_analytics_nodes != null && var.database_analytics_nodes > 0 ? {
+          instance_size   = var.database_cluster_instance_size
+          node_count      = var.database_analytics_nodes
+          disk_iops       = var.database_storage_ipos
+          ebs_volume_type = var.database_storage_type
+          disk_size_gb    = var.is_database_autoscaling_disk_gb_enabled ? null : var.database_storage_size
+        } : null
+
+        read_only_specs = var.database_read_only_nodes != null && var.database_read_only_nodes > 0 ? {
+          instance_size   = var.database_cluster_instance_size
+          node_count      = var.database_read_only_nodes
+          disk_iops       = var.database_storage_ipos
+          ebs_volume_type = var.database_storage_type
+          disk_size_gb    = var.is_database_autoscaling_disk_gb_enabled ? null : var.database_storage_size
+        } : null
+
+        auto_scaling = merge(
+          {
+            disk_gb_enabled            = var.is_database_autoscaling_disk_gb_enabled
+            compute_enabled            = var.is_database_autoscaling_compute_enabled
+            compute_scale_down_enabled = var.is_database_autoscaling_compute_enabled
+          },
+          var.is_database_autoscaling_compute_enabled ? {
+            compute_min_instance_size = var.database_autoscaling_min_instances
+            compute_max_instance_size = var.database_autoscaling_max_instances
+          } : {}
+        )
+      }]
+    }
+  ]
 }
 
 resource "mongodbatlas_cloud_backup_schedule" "backup_schedule" {
-  project_id   = mongodbatlas_cluster.cluster.project_id
-  cluster_name = mongodbatlas_cluster.cluster.name
+  project_id   = mongodbatlas_advanced_cluster.cluster.project_id
+  cluster_name = mongodbatlas_advanced_cluster.cluster.name
 
   restore_window_days = var.database_backup_retention_period
 
@@ -108,9 +128,11 @@ resource "aws_vpc_peering_connection_accepter" "accept_mongo_peer" {
   auto_accept               = true
 }
 
-# Add peering connection to private routing table
+# Add peering connection to private routing tables so EKS nodes can reach Atlas
 resource "aws_route" "peeraccess" {
-  route_table_id            = data.aws_vpc.main.main_route_table_id
+  count = length(var.private_route_table_ids)
+
+  route_table_id            = var.private_route_table_ids[count.index]
   destination_cidr_block    = var.mongodbatlas_cidr_block
   vpc_peering_connection_id = mongodbatlas_network_peering.cluster_network_peering.connection_id
   depends_on = [
@@ -153,6 +175,6 @@ resource "mongodbatlas_database_user" "users" {
 
   scopes {
     type = "CLUSTER"
-    name = mongodbatlas_cluster.cluster.name
+    name = mongodbatlas_advanced_cluster.cluster.name
   }
 }

--- a/terraform/modules/aws/mongodb/outputs.tf
+++ b/terraform/modules/aws/mongodb/outputs.tf
@@ -1,20 +1,20 @@
 output "database_cluster_id" {
-  value       = mongodbatlas_cluster.cluster.id
+  value       = mongodbatlas_advanced_cluster.cluster.cluster_id
   description = "The unique resource ID of the database cluster"
 }
 
 output "database_cluster_cluster_id" {
-  value       = mongodbatlas_cluster.cluster.cluster_id
+  value       = mongodbatlas_advanced_cluster.cluster.cluster_id
   description = "The cluster ID of the database cluster"
 }
 
 output "cluster_address" {
-  value       = mongodbatlas_cluster.cluster.srv_address
+  value       = mongodbatlas_advanced_cluster.cluster.connection_strings.standard_srv
   description = "The address of the database cluster"
 }
 
 output "cluster_connection_strings" {
-  value       = mongodbatlas_cluster.cluster.connection_strings
+  value       = mongodbatlas_advanced_cluster.cluster.connection_strings
   description = "Connection strings for the database cluster"
 }
 

--- a/terraform/modules/aws/mongodb/outputs.tf
+++ b/terraform/modules/aws/mongodb/outputs.tf
@@ -22,9 +22,9 @@ output "database_user_credentials" {
   value = {
     for key, user in var.database_users :
     key => {
-      username       = user.username
-      password       = try(mongodbatlas_database_user.users[user.username].password, "")
-      database       = user.database
+      username = user.username
+      password = try(mongodbatlas_database_user.users[user.username].password, "")
+      database = user.database
     }
   }
   description = "List of database and user credentials mapping."

--- a/terraform/modules/aws/mongodb/variables.tf
+++ b/terraform/modules/aws/mongodb/variables.tf
@@ -120,13 +120,18 @@ variable "database_backup_retention_period" {
 
 variable "is_database_storage_encrypted" {
   type        = bool
-  description = "Whether the database storage is encrypted in rest"
-  default     = true
+  description = "Enable Atlas Encryption at Rest with customer-managed AWS KMS keys"
+  default     = false
 }
 
 variable "vpc_id" {
   type        = string
   description = "ID of the VPC to use for the MongoDB cluster"
+}
+
+variable "private_route_table_ids" {
+  type        = list(string)
+  description = "Private route table IDs that should route to the Atlas peering connection"
 }
 
 variable "database_users" {

--- a/terraform/modules/aws/mongodb/variables.tf
+++ b/terraform/modules/aws/mongodb/variables.tf
@@ -131,8 +131,8 @@ variable "vpc_id" {
 
 variable "database_users" {
   type = map(object({
-    username       = string
-    database       = string
+    username = string
+    database = string
   }))
   default     = {}
   description = "Map of additional user and database names."

--- a/terraform/modules/aws/rds/README.md
+++ b/terraform/modules/aws/rds/README.md
@@ -29,7 +29,6 @@ No modules.
 | [random_password.rds_root_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_string.rds_final_snapshot_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.rds_root_username](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [aws_subnets.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
@@ -53,6 +52,7 @@ No modules.
 | <a name="input_is_auto_minor_version_upgrade_enabled"></a> [is\_auto\_minor\_version\_upgrade\_enabled](#input\_is\_auto\_minor\_version\_upgrade\_enabled) | Whether automatic minor version upgrades are enabled | `bool` | `false` | no |
 | <a name="input_is_database_storage_alarm_enabled"></a> [is\_database\_storage\_alarm\_enabled](#input\_is\_database\_storage\_alarm\_enabled) | Whether database storage alarms are enabled | `bool` | `true` | no |
 | <a name="input_is_database_storage_encrypted"></a> [is\_database\_storage\_encrypted](#input\_is\_database\_storage\_encrypted) | Whether the database storage is encrypted in rest | `bool` | `true` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Private subnet IDs for the RDS subnet group | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC to use for the RDS cluster | `string` | n/a | yes |
 

--- a/terraform/modules/aws/rds/README.md
+++ b/terraform/modules/aws/rds/README.md
@@ -1,13 +1,17 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.62 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.62 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.9 |
 
 ## Modules
 
@@ -16,7 +20,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_metric_alarm.rds_storage_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_db_instance.rds_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
 | [aws_db_subnet_group.rds_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
@@ -31,7 +35,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_database_backup_retention_period"></a> [database\_backup\_retention\_period](#input\_database\_backup\_retention\_period) | The retention period for the database backups in days | `number` | `35` | no |
 | <a name="input_database_ca_cert_identifier"></a> [database\_ca\_cert\_identifier](#input\_database\_ca\_cert\_identifier) | The CA certificate identifier if any | `string` | `null` | no |
 | <a name="input_database_cluster_instance_size"></a> [database\_cluster\_instance\_size](#input\_database\_cluster\_instance\_size) | Database instance size | `string` | `"db.t3.micro"` | no |
@@ -55,7 +59,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cluster_connection_endpoint"></a> [cluster\_connection\_endpoint](#output\_cluster\_connection\_endpoint) | The endpoint URL on which the database cluster is accessible |
 | <a name="output_cluster_host"></a> [cluster\_host](#output\_cluster\_host) | The hostname of the database cluster |
 | <a name="output_cluster_port"></a> [cluster\_port](#output\_cluster\_port) | The port on which the database cluster is waiting for client connections |

--- a/terraform/modules/aws/rds/main.tf
+++ b/terraform/modules/aws/rds/main.tf
@@ -17,17 +17,6 @@ data "aws_vpc" "main" {
   id = var.vpc_id
 }
 
-data "aws_subnets" "main" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.main.id]
-  }
-
-  tags = {
-    Tier = "Private"
-  }
-}
-
 resource "random_string" "rds_root_username" {
   length  = 16
   special = false
@@ -53,7 +42,7 @@ resource "aws_kms_key" "rds_encryption" {
 
 resource "aws_db_subnet_group" "rds_subnet_group" {
   name       = "${var.database_cluster_name} rds subnet group"
-  subnet_ids = data.aws_subnets.main.ids
+  subnet_ids = var.subnet_ids
 
   tags = merge(var.tags, {
     name = "${var.database_cluster_name} rds subnet group"

--- a/terraform/modules/aws/rds/main.tf
+++ b/terraform/modules/aws/rds/main.tf
@@ -1,10 +1,14 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 6.62"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.9"
     }
   }
 }

--- a/terraform/modules/aws/rds/variables.tf
+++ b/terraform/modules/aws/rds/variables.tf
@@ -103,6 +103,11 @@ variable "vpc_id" {
   description = "ID of the VPC to use for the RDS cluster"
 }
 
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for the RDS subnet group"
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of tags to add to all resources"

--- a/terraform/modules/aws/s3/README.md
+++ b/terraform/modules/aws/s3/README.md
@@ -1,13 +1,17 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.62 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.62 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.9 |
 
 ## Modules
 
@@ -16,7 +20,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_kms_key.s3_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.s3_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
@@ -31,7 +35,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_allowed_cors_origins"></a> [allowed\_cors\_origins](#input\_allowed\_cors\_origins) | Lists the CORS origins to allow CORS requests from. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | The prefix for the AWS s3 bucket for easier identification. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The AWS project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
@@ -43,7 +47,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | The unique resource ID of the bucket. |
 | <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | The domain name of the bucket, including the generated prefix. |
 | <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | The ID of the bucket that is generated during creation. |

--- a/terraform/modules/aws/s3/main.tf
+++ b/terraform/modules/aws/s3/main.tf
@@ -1,11 +1,15 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 6.62"
     }
 
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.9"
     }
   }
 }

--- a/terraform/modules/aws/s3/outputs.tf
+++ b/terraform/modules/aws/s3/outputs.tf
@@ -9,8 +9,8 @@ output "bucket_arn" {
 }
 
 output "bucket_name" {
-   value       = aws_s3_bucket.s3_bucket.name 
-   description = "The name of the S3 bucket."
+  value       = aws_s3_bucket.s3_bucket.bucket
+  description = "The name of the S3 bucket."
 }
 
 output "bucket_domain_name" {

--- a/terraform/modules/aws/vpc/README.md
+++ b/terraform/modules/aws/vpc/README.md
@@ -1,29 +1,33 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.62 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| ---- | ------- |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.9 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.17 |
+| ---- | ------ | ------- |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 6.7 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [random_id.vpc_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of availability zones to use | `list(string)` | `[]` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | CIDR block for the VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable NAT Gateway | `bool` | `true` | no |
@@ -40,7 +44,7 @@ No requirements.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_database_subnet_arns"></a> [database\_subnet\_arns](#output\_database\_subnet\_arns) | List of ARNs of database subnets |
 | <a name="output_database_subnet_group"></a> [database\_subnet\_group](#output\_database\_subnet\_group) | ID of database subnet group |
 | <a name="output_database_subnet_group_name"></a> [database\_subnet\_group\_name](#output\_database\_subnet\_group\_name) | Name of database subnet group |

--- a/terraform/modules/aws/vpc/README.md
+++ b/terraform/modules/aws/vpc/README.md
@@ -54,6 +54,7 @@
 | <a name="output_default_vpc_arn"></a> [default\_vpc\_arn](#output\_default\_vpc\_arn) | The ARN of the Default VPC |
 | <a name="output_default_vpc_cidr_block"></a> [default\_vpc\_cidr\_block](#output\_default\_vpc\_cidr\_block) | The CIDR block of the Default VPC |
 | <a name="output_default_vpc_id"></a> [default\_vpc\_id](#output\_default\_vpc\_id) | The ID of the Default VPC |
+| <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | List of IDs of private route tables |
 | <a name="output_private_subnet_arns"></a> [private\_subnet\_arns](#output\_private\_subnet\_arns) | List of ARNs of private subnets |
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of IDs of private subnets |
 | <a name="output_private_subnets_cidr_blocks"></a> [private\_subnets\_cidr\_blocks](#output\_private\_subnets\_cidr\_blocks) | List of cidr\_blocks of private subnets |

--- a/terraform/modules/aws/vpc/main.tf
+++ b/terraform/modules/aws/vpc/main.tf
@@ -1,11 +1,15 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 6.62"
     }
 
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.9"
     }
   }
 }
@@ -17,7 +21,7 @@ resource "random_id" "vpc_suffix" {
 
 module "vpc" {
   source          = "terraform-aws-modules/vpc/aws"
-  version         = "~> 5.17"
+  version         = "~> 6.7"
   name            = var.vpc_name == "" ? "open-edx-${var.environment}-vpc-${random_id.vpc_suffix[0].dec}" : var.vpc_name
   cidr            = var.cidr
   azs             = var.availability_zones
@@ -34,7 +38,7 @@ module "vpc" {
   single_nat_gateway     = var.single_nat_gateway
   one_nat_gateway_per_az = var.one_nat_gateway_per_az
 
-  tags = var.tags
-  public_subnet_tags = var.public_subnet_tags
+  tags                = var.tags
+  public_subnet_tags  = var.public_subnet_tags
   private_subnet_tags = var.private_subnet_tags
 }

--- a/terraform/modules/aws/vpc/outputs.tf
+++ b/terraform/modules/aws/vpc/outputs.tf
@@ -28,6 +28,11 @@ output "private_subnets" {
   value       = module.vpc.private_subnets
 }
 
+output "private_route_table_ids" {
+  description = "List of IDs of private route tables"
+  value       = module.vpc.private_route_table_ids
+}
+
 output "private_subnet_arns" {
   description = "List of ARNs of private subnets"
   value       = module.vpc.private_subnet_arns

--- a/terraform/modules/digitalocean/database/README.md
+++ b/terraform/modules/digitalocean/database/README.md
@@ -1,13 +1,17 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | ~> 2.100 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.3 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | n/a |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| ---- | ------- |
+| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | ~> 2.100 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.3 |
 
 ## Modules
 
@@ -16,18 +20,17 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [digitalocean_database_cluster.database_cluster](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/database_cluster) | resource |
 | [digitalocean_database_db.databases](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/database_db) | resource |
 | [digitalocean_database_firewall.database_cluster_firewall](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/database_firewall) | resource |
 | [digitalocean_database_user.users](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/database_user) | resource |
 | [null_resource.no_primary_key_patch_database_cluster](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [digitalocean_vpc.vpc](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_access_token"></a> [access\_token](#input\_access\_token) | DigitalOcean access token in order to patch the database settings. | `string` | n/a | yes |
 | <a name="input_database_cluster_instance_size"></a> [database\_cluster\_instance\_size](#input\_database\_cluster\_instance\_size) | Database instance size. | `string` | `"s-1vcpu-1gb"` | no |
 | <a name="input_database_cluster_instances"></a> [database\_cluster\_instances](#input\_database\_cluster\_instances) | Number of nodes in the database cluster. | `number` | `1` | no |
@@ -45,7 +48,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cluster_connection_string"></a> [cluster\_connection\_string](#output\_cluster\_connection\_string) | The URI to use as a connection string for the database cluster. |
 | <a name="output_cluster_host"></a> [cluster\_host](#output\_cluster\_host) | The hostname of the database cluster. |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The unique resource ID of the database cluster. |

--- a/terraform/modules/digitalocean/database/main.tf
+++ b/terraform/modules/digitalocean/database/main.tf
@@ -1,13 +1,17 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     digitalocean = {
-      source = "digitalocean/digitalocean"
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.100"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.3"
     }
   }
-}
-
-data "digitalocean_vpc" "vpc" {
-  id = var.vpc_id
 }
 
 resource "digitalocean_database_cluster" "database_cluster" {
@@ -21,7 +25,7 @@ resource "digitalocean_database_cluster" "database_cluster" {
   tags                 = []
 
   maintenance_window {
-    day = var.database_maintenance_window_day
+    day  = var.database_maintenance_window_day
     hour = var.database_maintenance_window_time
   }
 }

--- a/terraform/modules/digitalocean/database/outputs.tf
+++ b/terraform/modules/digitalocean/database/outputs.tf
@@ -1,37 +1,37 @@
 output "cluster_id" {
-  value     = digitalocean_database_cluster.database_cluster.id
+  value       = digitalocean_database_cluster.database_cluster.id
   description = "The unique resource ID of the database cluster."
 }
 
 output "cluster_urn" {
-  value     = digitalocean_database_cluster.database_cluster.urn
+  value       = digitalocean_database_cluster.database_cluster.urn
   description = "The unique resource ID of the database cluster."
 }
 
 output "cluster_root_user" {
-  value     = digitalocean_database_cluster.database_cluster.user
+  value       = digitalocean_database_cluster.database_cluster.user
   description = "Database root user"
-  sensitive = true
+  sensitive   = true
 }
 
 output "cluster_root_password" {
-  value     = digitalocean_database_cluster.database_cluster.password
+  value       = digitalocean_database_cluster.database_cluster.password
   description = "Database root user password"
-  sensitive = true
+  sensitive   = true
 }
 
 output "cluster_host" {
-  value = digitalocean_database_cluster.database_cluster.host
+  value       = digitalocean_database_cluster.database_cluster.host
   description = "The hostname of the database cluster."
 }
 
 output "cluster_port" {
-  value = digitalocean_database_cluster.database_cluster.port
+  value       = digitalocean_database_cluster.database_cluster.port
   description = "The port on which the database cluster is waiting for client connections."
 }
 
 output "cluster_connection_string" {
-  value = digitalocean_database_cluster.database_cluster.uri
+  value       = digitalocean_database_cluster.database_cluster.uri
   description = "The URI to use as a connection string for the database cluster."
 }
 
@@ -45,5 +45,5 @@ output "database_user_credentials" {
     }
   }
   description = "List of database and user credentials mapping."
-  sensitive = true
+  sensitive   = true
 }

--- a/terraform/modules/digitalocean/database/variables.tf
+++ b/terraform/modules/digitalocean/database/variables.tf
@@ -1,5 +1,5 @@
 variable "access_token" {
-  type = string
+  type        = string
   description = "DigitalOcean access token in order to patch the database settings."
 }
 
@@ -52,10 +52,10 @@ variable "database_cluster_instance_size" {
 }
 
 variable "database_maintenance_window_day" {
-  type = string
-  default = "sunday"
+  type        = string
+  default     = "sunday"
   description = "The day when maintenance can be executed on the database cluster."
-  
+
   validation {
     condition = contains([
       "monday",
@@ -71,7 +71,7 @@ variable "database_maintenance_window_day" {
 }
 
 variable "database_maintenance_window_time" {
-  type = string
+  type        = string
   description = "The hour in UTC at which maintenance updates will be applied in 24 hour format."
 }
 
@@ -85,12 +85,12 @@ variable "database_users" {
 }
 
 variable "kubernetes_cluster_name" {
-  type = string
+  type        = string
   description = "The name of the Kubernetes cluster."
 }
 
 variable "vpc_id" {
-  type = string
+  type        = string
   description = "ID of the VPC to use for the Kubernetes cluster."
 }
 

--- a/terraform/modules/digitalocean/doks/README.md
+++ b/terraform/modules/digitalocean/doks/README.md
@@ -1,12 +1,15 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | ~> 2.100 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | n/a |
+| ---- | ------- |
+| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | ~> 2.100 |
 
 ## Modules
 
@@ -15,7 +18,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [digitalocean_kubernetes_cluster.cluster](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster) | resource |
 | [digitalocean_kubernetes_node_pool.additional_node_pools](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_node_pool) | resource |
 | [digitalocean_tag.worker_firewall](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/tag) | resource |
@@ -24,13 +27,13 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_node_pools"></a> [additional\_node\_pools](#input\_additional\_node\_pools) | Additional node pools attached to the cluster. | <pre>list(object({<br/>    name           = string<br/>    size           = string<br/>    min_node_count = number<br/>    max_node_count = number<br/>    labels         = optional(map(any))<br/>  }))</pre> | `[]` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the Kubernetes cluster. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The DigitalOcean project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
-| <a name="input_is_auto_scaling_enabled"></a> [is\_auto\_scaling\_enabled](#input\_is\_auto\_scaling\_enabled) | Whether auto scaling is enabled for the cluster or not. | `bool` | n/a | yes |
-| <a name="input_is_auto_upgrade_enabled"></a> [is\_auto\_upgrade\_enabled](#input\_is\_auto\_upgrade\_enabled) | Whether auto upgrade is enabled for the cluster or not. | `bool` | n/a | yes |
-| <a name="input_is_surge_upgrade_enabled"></a> [is\_surge\_upgrade\_enabled](#input\_is\_surge\_upgrade\_enabled) | Whether surge upgrade is enabled for the cluster or not. | `bool` | n/a | yes |
+| <a name="input_is_auto_scaling_enabled"></a> [is\_auto\_scaling\_enabled](#input\_is\_auto\_scaling\_enabled) | Whether auto scaling is enabled for the cluster or not. | `bool` | `true` | no |
+| <a name="input_is_auto_upgrade_enabled"></a> [is\_auto\_upgrade\_enabled](#input\_is\_auto\_upgrade\_enabled) | Whether auto upgrade is enabled for the cluster or not. | `bool` | `true` | no |
+| <a name="input_is_surge_upgrade_enabled"></a> [is\_surge\_upgrade\_enabled](#input\_is\_surge\_upgrade\_enabled) | Whether surge upgrade is enabled for the cluster or not. | `bool` | `true` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The supported Kubernetes version to install for the cluster. | `string` | n/a | yes |
 | <a name="input_max_worker_node_count"></a> [max\_worker\_node\_count](#input\_max\_worker\_node\_count) | Maximum number of running Kubernetes worker nodes. | `number` | `5` | no |
 | <a name="input_min_worker_node_count"></a> [min\_worker\_node\_count](#input\_min\_worker\_node\_count) | Minimum number of running Kubernetes worker nodes. | `number` | `3` | no |
@@ -41,8 +44,9 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | Endpoint of the Kubernetes cluster. |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The ID of the Kubernetes cluster that is generated during creation. |
 | <a name="output_cluster_ipv4"></a> [cluster\_ipv4](#output\_cluster\_ipv4) | IPv4 address of the Kubernetes cluster. |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the Kubernetes cluster. |
 | <a name="output_cluster_urn"></a> [cluster\_urn](#output\_cluster\_urn) | The unique resource ID of the Kubernetes cluster. |

--- a/terraform/modules/digitalocean/doks/main.tf
+++ b/terraform/modules/digitalocean/doks/main.tf
@@ -1,7 +1,10 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     digitalocean = {
-      source = "digitalocean/digitalocean"
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.100"
     }
   }
 }
@@ -15,11 +18,11 @@ resource "digitalocean_tag" "worker_firewall" {
 }
 
 resource "digitalocean_kubernetes_cluster" "cluster" {
-  name         = "${var.cluster_name}-${var.environment}"
-  region       = var.region
-  version      = var.kubernetes_version
-  vpc_uuid     = data.digitalocean_vpc.vpc.id
-  auto_upgrade = var.is_auto_upgrade_enabled
+  name          = "${var.cluster_name}-${var.environment}"
+  region        = var.region
+  version       = var.kubernetes_version
+  vpc_uuid      = data.digitalocean_vpc.vpc.id
+  auto_upgrade  = var.is_auto_upgrade_enabled
   surge_upgrade = var.is_surge_upgrade_enabled
 
   lifecycle {

--- a/terraform/modules/digitalocean/doks/outputs.tf
+++ b/terraform/modules/digitalocean/doks/outputs.tf
@@ -1,24 +1,24 @@
 output "cluster_id" {
-  value = digitalocean_kubernetes_cluster.cluster.id
+  value       = digitalocean_kubernetes_cluster.cluster.id
   description = "The ID of the Kubernetes cluster that is generated during creation."
 }
 
 output "cluster_urn" {
-  value = digitalocean_kubernetes_cluster.cluster.urn
+  value       = digitalocean_kubernetes_cluster.cluster.urn
   description = "The unique resource ID of the Kubernetes cluster."
 }
 
 output "cluster_name" {
-  value = digitalocean_kubernetes_cluster.cluster.name
+  value       = digitalocean_kubernetes_cluster.cluster.name
   description = "The name of the Kubernetes cluster."
 }
 
 output "cluster_ipv4" {
-  value = digitalocean_kubernetes_cluster.cluster.ipv4_address
+  value       = digitalocean_kubernetes_cluster.cluster.ipv4_address
   description = "IPv4 address of the Kubernetes cluster."
 }
 
 output "cluster_endpoint" {
-  value = digitalocean_kubernetes_cluster.cluster.endpoint
+  value       = digitalocean_kubernetes_cluster.cluster.endpoint
   description = "Endpoint of the Kubernetes cluster."
 }

--- a/terraform/modules/digitalocean/doks/variables.tf
+++ b/terraform/modules/digitalocean/doks/variables.tf
@@ -24,12 +24,12 @@ variable "environment" {
 }
 
 variable "cluster_name" {
-  type = string
+  type        = string
   description = "The name of the Kubernetes cluster."
 }
 
 variable "kubernetes_version" {
-  type = string
+  type        = string
   description = "The supported Kubernetes version to install for the cluster."
 }
 
@@ -64,24 +64,24 @@ variable "max_worker_node_count" {
 }
 
 variable "vpc_id" {
-  type = string
+  type        = string
   description = "ID of the VPC to use for the Kubernetes cluster."
 }
 
 variable "is_auto_upgrade_enabled" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Whether auto upgrade is enabled for the cluster or not."
 }
 
 variable "is_surge_upgrade_enabled" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Whether surge upgrade is enabled for the cluster or not."
 }
 
 variable "is_auto_scaling_enabled" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Whether auto scaling is enabled for the cluster or not."
 }

--- a/terraform/modules/digitalocean/spaces/README.md
+++ b/terraform/modules/digitalocean/spaces/README.md
@@ -1,13 +1,17 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | ~> 2.100 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| ---- | ------- |
+| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | ~> 2.100 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.9 |
 
 ## Modules
 
@@ -16,7 +20,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [digitalocean_spaces_bucket.spaces_bucket](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/spaces_bucket) | resource |
 | [digitalocean_spaces_bucket_cors_configuration.spaces_bucket_policy](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/spaces_bucket_cors_configuration) | resource |
 | [digitalocean_spaces_bucket_policy.public_root_object_policy](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/spaces_bucket_policy) | resource |
@@ -25,7 +29,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_allowed_cors_origins"></a> [allowed\_cors\_origins](#input\_allowed\_cors\_origins) | Lists the CORS origins to allow CORS requests from. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | The prefix for the DigitalOcean spaces bucket for easier identification. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The DigitalOcean project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
@@ -37,7 +41,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | The ID of the bucket that is generated during creation. |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | The name of the bucket, including the generated suffix. |
 | <a name="output_bucket_urn"></a> [bucket\_urn](#output\_bucket\_urn) | The unique resource ID of the bucket. |

--- a/terraform/modules/digitalocean/spaces/main.tf
+++ b/terraform/modules/digitalocean/spaces/main.tf
@@ -1,11 +1,15 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.9"
     }
 
     digitalocean = {
-      source = "digitalocean/digitalocean"
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.100"
     }
   }
 }
@@ -51,7 +55,7 @@ resource "digitalocean_spaces_bucket_cors_configuration" "spaces_bucket_policy" 
 }
 
 resource "digitalocean_spaces_bucket_policy" "public_root_object_policy" {
-  count  = var.is_public ? 1 : 0
+  count = var.is_public ? 1 : 0
 
   bucket = digitalocean_spaces_bucket.spaces_bucket.name
   region = var.region

--- a/terraform/modules/digitalocean/spaces/outputs.tf
+++ b/terraform/modules/digitalocean/spaces/outputs.tf
@@ -1,14 +1,14 @@
 output "bucket_id" {
-  value = digitalocean_spaces_bucket.spaces_bucket.id
+  value       = digitalocean_spaces_bucket.spaces_bucket.id
   description = "The ID of the bucket that is generated during creation."
 }
 
 output "bucket_urn" {
-  value = digitalocean_spaces_bucket.spaces_bucket.urn
+  value       = digitalocean_spaces_bucket.spaces_bucket.urn
   description = "The unique resource ID of the bucket."
 }
 
 output "bucket_name" {
-  value = digitalocean_spaces_bucket.spaces_bucket.name
+  value       = digitalocean_spaces_bucket.spaces_bucket.name
   description = "The name of the bucket, including the generated suffix."
 }

--- a/terraform/modules/digitalocean/spaces/variables.tf
+++ b/terraform/modules/digitalocean/spaces/variables.tf
@@ -24,31 +24,31 @@ variable "environment" {
 }
 
 variable "bucket_prefix" {
-  type = string
+  type        = string
   description = "The prefix for the DigitalOcean spaces bucket for easier identification."
 }
 
 variable "allowed_cors_origins" {
-  type    = list(string)
-  default = ["*"]
+  type        = list(string)
+  default     = ["*"]
   description = "Lists the CORS origins to allow CORS requests from."
 }
 
 variable "is_public" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Determines whether the DigitalOcean spaces bucket's root object is publicly available or not."
 }
 
 variable "is_force_destroy_enabled" {
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Determines if the DigitalOcean spaces bucket is force-destroyed or not upon deletion."
 }
 
 variable "is_versioning_enabled" {
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Determines if versioning is allowed on the DigitalOcean spaces bucket or not."
 }
 

--- a/terraform/modules/digitalocean/vpc/README.md
+++ b/terraform/modules/digitalocean/vpc/README.md
@@ -1,13 +1,17 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | ~> 2.100 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| ---- | ------- |
+| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | ~> 2.100 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.9 |
 
 ## Modules
 
@@ -16,14 +20,14 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [digitalocean_vpc.vpc](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/vpc) | resource |
 | [random_id.vpc_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_environment"></a> [environment](#input\_environment) | The DigitalOcean project environment. (for example: production, staging, development, etc.) | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | DigitalOcean region to create the resources in. | `string` | n/a | yes |
 | <a name="input_vpc_ip_range"></a> [vpc\_ip\_range](#input\_vpc\_ip\_range) | IP range assigned to the VPC. | `string` | `"10.10.0.0/24"` | no |
@@ -32,7 +36,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC that is generated during creation. |
 | <a name="output_vpc_ip_range"></a> [vpc\_ip\_range](#output\_vpc\_ip\_range) | The IP range that is covered by the VPC. |
 | <a name="output_vpc_name"></a> [vpc\_name](#output\_vpc\_name) | The name of the VPC, including the generated suffix, if any. |

--- a/terraform/modules/digitalocean/vpc/main.tf
+++ b/terraform/modules/digitalocean/vpc/main.tf
@@ -1,17 +1,21 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.9"
     }
 
     digitalocean = {
-      source = "digitalocean/digitalocean"
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.100"
     }
   }
 }
 
 resource "random_id" "vpc_suffix" {
-  count = var.vpc_name == "" ? 1 : 0
+  count       = var.vpc_name == "" ? 1 : 0
   byte_length = 8
 }
 

--- a/terraform/modules/digitalocean/vpc/outputs.tf
+++ b/terraform/modules/digitalocean/vpc/outputs.tf
@@ -1,19 +1,19 @@
 output "vpc_id" {
-  value = digitalocean_vpc.vpc.id
+  value       = digitalocean_vpc.vpc.id
   description = "The ID of the VPC that is generated during creation."
 }
 
 output "vpc_urn" {
-  value = digitalocean_vpc.vpc.urn
+  value       = digitalocean_vpc.vpc.urn
   description = "The unique resource ID of the VPC."
 }
 
 output "vpc_name" {
-  value = digitalocean_vpc.vpc.name
+  value       = digitalocean_vpc.vpc.name
   description = "The name of the VPC, including the generated suffix, if any."
 }
 
 output "vpc_ip_range" {
-  value = digitalocean_vpc.vpc.ip_range
+  value       = digitalocean_vpc.vpc.ip_range
   description = "The IP range that is covered by the VPC."
 }

--- a/terraform/modules/digitalocean/vpc/variables.tf
+++ b/terraform/modules/digitalocean/vpc/variables.tf
@@ -24,8 +24,8 @@ variable "environment" {
 }
 
 variable "vpc_name" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Optional custom name for the VPC. If not provided, a name will be generated."
 }
 


### PR DESCRIPTION
## Description

This PR bumps the terraform modules to their latest versions, refactors the code to replace deprecated resource definitions and updates the infra examples to make sure everything is wired correctly.

Private ticket: SE-6607

## Testing

These changes were tested by spinning up an AWS cluster and by updating an existing DigitalOcean cluster (as that module didn't really change).